### PR TITLE
Migrate to OH embedded Jetty HttpClient 

### DIFF
--- a/bundles/org.openhab.binding.lgthinq/pom.xml
+++ b/bundles/org.openhab.binding.lgthinq/pom.xml
@@ -14,6 +14,24 @@
   <name>openHAB Add-ons :: Bundles :: LG Thinq Binding</name>
 
   <dependencies>
+  	<dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>

--- a/bundles/org.openhab.binding.lgthinq/pom.xml
+++ b/bundles/org.openhab.binding.lgthinq/pom.xml
@@ -12,48 +12,14 @@
   <artifactId>org.openhab.binding.lgthinq</artifactId>
 
   <name>openHAB Add-ons :: Bundles :: LG Thinq Binding</name>
-  <properties>
-    <bnd.importpackage>!net.sf.ehcache.*,!net.spy.*</bnd.importpackage>
-  </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-osgi</artifactId>
-      <version>4.5.13</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore-osgi</artifactId>
-      <version>4.4.10</version>
-      <scope>compile</scope>
-    </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>
       <version>2.32.0</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/bundles/org.openhab.binding.lgthinq/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.lgthinq/src/main/feature/feature.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.lgthinq-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+	
 	<feature name="openhab-binding-lgthinq" description="lgthinq Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
-		<bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/4.5.13</bundle>
-		<bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/4.4.10</bundle>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.lgthinq/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/LGThinQHandlerFactory.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/LGThinQHandlerFactory.java
@@ -22,6 +22,7 @@ import org.openhab.binding.lgthinq.internal.handler.*;
 import org.openhab.binding.lgthinq.internal.type.ThinqChannelGroupTypeProvider;
 import org.openhab.binding.lgthinq.internal.type.ThinqChannelTypeProvider;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
@@ -47,6 +48,9 @@ import org.slf4j.LoggerFactory;
 public class LGThinQHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(LGThinQHandlerFactory.class);
+    
+	private HttpClientFactory httpClientFactory;
+	
     private final LGThinQStateDescriptionProvider stateDescriptionProvider;
 
     @Nullable
@@ -59,6 +63,13 @@ public class LGThinQHandlerFactory extends BaseThingHandlerFactory {
     @Reference
     protected ItemChannelLinkRegistry itemChannelLinkRegistry;
 
+	@Activate
+	public LGThinQHandlerFactory(final @Reference LGThinQStateDescriptionProvider stateDescriptionProvider,
+			@Reference final HttpClientFactory httpClientFactory) {
+		this.stateDescriptionProvider = stateDescriptionProvider;
+		this.httpClientFactory = httpClientFactory;
+	}
+
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return LGThinQBindingConstants.SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
@@ -69,20 +80,20 @@ public class LGThinQHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
         if (THING_TYPE_AIR_CONDITIONER.equals(thingTypeUID) || THING_TYPE_HEAT_PUMP.equals(thingTypeUID)) {
             return new LGThinQAirConditionerHandler(thing, stateDescriptionProvider,
-                    Objects.requireNonNull(itemChannelLinkRegistry));
+                    Objects.requireNonNull(itemChannelLinkRegistry), httpClientFactory);
         } else if (THING_TYPE_BRIDGE.equals(thingTypeUID)) {
-            return new LGThinQBridgeHandler((Bridge) thing);
+            return new LGThinQBridgeHandler((Bridge) thing, httpClientFactory);
         } else if (THING_TYPE_WASHING_MACHINE.equals(thingTypeUID) || THING_TYPE_WASHING_TOWER.equals(thingTypeUID)) {
             return new LGThinQWasherDryerHandler(thing, stateDescriptionProvider,
                     Objects.requireNonNull(thinqChannelProvider), Objects.requireNonNull(thinqChannelGroupProvider),
-                    Objects.requireNonNull(itemChannelLinkRegistry));
+                    Objects.requireNonNull(itemChannelLinkRegistry), httpClientFactory);
         } else if (THING_TYPE_DRYER.equals(thingTypeUID) || THING_TYPE_DRYER_TOWER.equals(thingTypeUID)) {
             return new LGThinQWasherDryerHandler(thing, stateDescriptionProvider,
                     Objects.requireNonNull(thinqChannelProvider), Objects.requireNonNull(thinqChannelGroupProvider),
-                    Objects.requireNonNull(itemChannelLinkRegistry));
+                    Objects.requireNonNull(itemChannelLinkRegistry), httpClientFactory);
         } else if (THING_TYPE_FRIDGE.equals(thingTypeUID)) {
             return new LGThinQFridgeHandler(thing, stateDescriptionProvider,
-                    Objects.requireNonNull(itemChannelLinkRegistry));
+                    Objects.requireNonNull(itemChannelLinkRegistry), httpClientFactory);
         }
         logger.error("Thing not supported by this Factory: {}", thingTypeUID.getId());
         return null;
@@ -105,8 +116,4 @@ public class LGThinQHandlerFactory extends BaseThingHandlerFactory {
         return null;
     }
 
-    @Activate
-    public LGThinQHandlerFactory(final @Reference LGThinQStateDescriptionProvider stateDescriptionProvider) {
-        this.stateDescriptionProvider = stateDescriptionProvider;
-    }
 }

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/api/RestUtils.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/api/RestUtils.java
@@ -100,7 +100,12 @@ public class RestUtils {
             @Nullable Map<String, String> params) throws IOException {
 
         Request request = httpClient.newRequest(encodedUrl).method("GET");
-        headers.forEach(request::header);
+        if (params != null) {
+            params.forEach(request::param);
+        }
+        if (headers != null) {
+            headers.forEach(request::header);
+        }
         ContentResponse response;
         try {
             response = request.send();
@@ -151,7 +156,9 @@ public class RestUtils {
                     .method("POST")
                     .content(contentProvider)
                     .timeout(10, TimeUnit.SECONDS);
-            headers.forEach(request::header);
+            if (headers != null) {
+                headers.forEach(request::header);
+            }
             ContentResponse response = request.content(contentProvider).timeout(10, TimeUnit.SECONDS)
                     .send();
             return new RestResult(response.getContentAsString(), response.getStatus());

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/api/RestUtils.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/api/RestUtils.java
@@ -106,14 +106,20 @@ public class RestUtils {
         if (headers != null) {
             headers.forEach(request::header);
         }
-        ContentResponse response;
+
+        if (logger.isTraceEnabled()) {
+            logger.trace("GET request: {}", request.getURI());
+        }
         try {
-            response = request.send();
+            ContentResponse response = request.send();
+
+            logger.trace("GET response: {}", response.getContentAsString());
+
+            return new RestResult(response.getContentAsString(), response.getStatus());
         } catch (InterruptedException | TimeoutException | ExecutionException e) {
             logger.error("Exception occurred during GET execution: {}", e.getMessage(), e);
             throw new CommunicationException(e);
         }
-        return new RestResult(response.getContentAsString(), response.getStatus());
     }
 
     @Nullable
@@ -159,8 +165,16 @@ public class RestUtils {
             if (headers != null) {
                 headers.forEach(request::header);
             }
-            ContentResponse response = request.content(contentProvider).timeout(10, TimeUnit.SECONDS)
+            if (logger.isTraceEnabled()) {
+                logger.trace("POST request: {}", request.getURI());
+            }
+
+            ContentResponse response = request.content(contentProvider)
+                    .timeout(10, TimeUnit.SECONDS)
                     .send();
+
+            logger.trace("POST response: {}", response.getContentAsString());
+
             return new RestResult(response.getContentAsString(), response.getStatus());
         } catch (TimeoutException e) {
             if (logger.isDebugEnabled()) {

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/api/TokenManager.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/api/TokenManager.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.lgthinq.internal.errors.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,17 +41,9 @@ public class TokenManager {
     private final OauthLgEmpAuthenticator oAuthAuthenticator;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final Map<String, TokenResult> tokenCached = new ConcurrentHashMap<>();
-    private static final TokenManager instance;
-    static {
-        instance = new TokenManager();
-    }
 
-    private TokenManager() {
-        oAuthAuthenticator = OauthLgEmpAuthenticator.getInstance();
-    }
-
-    public static TokenManager getInstance() {
-        return instance;
+    public TokenManager(HttpClient httpClient) {
+        oAuthAuthenticator = new OauthLgEmpAuthenticator(httpClient);
     }
 
     public boolean isTokenExpired(TokenResult token) {

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/discovery/LGThinqDiscoveryService.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/discovery/LGThinqDiscoveryService.java
@@ -56,6 +56,8 @@ public class LGThinqDiscoveryService extends AbstractDiscoveryService implements
 
     @Override
     protected void startScan() {
+        logger.debug("Scan started");
+        bridgeHandler.runDiscovery();
     }
 
     @Override
@@ -85,6 +87,7 @@ public class LGThinqDiscoveryService extends AbstractDiscoveryService implements
     }
 
     public void removeLgDeviceDiscovery(LGDevice device) {
+        logger.debug("Thing removed from discovery: {}", device.getDeviceId());
         try {
             ThingUID thingUID = getThingUID(device);
             thingRemoved(thingUID);
@@ -94,6 +97,7 @@ public class LGThinqDiscoveryService extends AbstractDiscoveryService implements
     }
 
     public void addLgDeviceDiscovery(LGDevice device) {
+        logger.debug("Thing added to discovery: {}", device.getDeviceId());
         String modelId = device.getModelName();
         ThingUID thingUID;
         ThingTypeUID thingTypeUID;

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/handler/LGThinQAirConditionerHandler.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/handler/LGThinQAirConditionerHandler.java
@@ -62,326 +62,328 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @NonNullByDefault
 public class LGThinQAirConditionerHandler extends LGThinQAbstractDeviceHandler<ACCapability, ACCanonicalSnapshot> {
 
-	public final ChannelGroupUID channelGroupExtendedInfoUID;
-	public final ChannelGroupUID channelGroupDashboardUID;
-	private final ChannelUID powerChannelUID;
-	private final ChannelUID opModeChannelUID;
-	private final ChannelUID fanSpeedChannelUID;
-	private final ChannelUID targetTempChannelUID;
-	private final ChannelUID currTempChannelUID;
-	private final ChannelUID jetModeChannelUID;
-	private final ChannelUID airCleanChannelUID;
-	private final ChannelUID autoDryChannelUID;
-	private final ChannelUID energySavingChannelUID;
-	private final ChannelUID extendedInfoCollectorChannelUID;
-	private final ChannelUID currentPowerEnergyChannelUID;
-	private final ChannelUID remainingFilterChannelUID;
+    public final ChannelGroupUID channelGroupExtendedInfoUID;
+    public final ChannelGroupUID channelGroupDashboardUID;
+    private final ChannelUID powerChannelUID;
+    private final ChannelUID opModeChannelUID;
+    private final ChannelUID fanSpeedChannelUID;
+    private final ChannelUID targetTempChannelUID;
+    private final ChannelUID currTempChannelUID;
+    private final ChannelUID jetModeChannelUID;
+    private final ChannelUID airCleanChannelUID;
+    private final ChannelUID autoDryChannelUID;
+    private final ChannelUID energySavingChannelUID;
+    private final ChannelUID extendedInfoCollectorChannelUID;
+    private final ChannelUID currentPowerEnergyChannelUID;
+    private final ChannelUID remainingFilterChannelUID;
 
-	private final ObjectMapper mapper = new ObjectMapper();
-	private final Logger logger = LoggerFactory.getLogger(LGThinQAirConditionerHandler.class);
-	@NonNullByDefault
-	private final LGThinQACApiClientService lgThinqACApiClientService;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Logger logger = LoggerFactory.getLogger(LGThinQAirConditionerHandler.class);
+    @NonNullByDefault
+    private final LGThinQACApiClientService lgThinqACApiClientService;
 
-	public LGThinQAirConditionerHandler(Thing thing, LGThinQStateDescriptionProvider stateDescriptionProvider,
-			ItemChannelLinkRegistry itemChannelLinkRegistry, HttpClientFactory httpClientFactory) {
-		super(thing, stateDescriptionProvider, itemChannelLinkRegistry);
-		lgThinqACApiClientService = LGThinQApiClientServiceFactory.newACApiClientService(lgPlatformType, httpClientFactory);
-		channelGroupDashboardUID = new ChannelGroupUID(getThing().getUID(), CHANNEL_DASHBOARD_GRP_ID);
-		channelGroupExtendedInfoUID = new ChannelGroupUID(getThing().getUID(), CHANNEL_EXTENDED_INFO_GRP_ID);
+    public LGThinQAirConditionerHandler(Thing thing, LGThinQStateDescriptionProvider stateDescriptionProvider,
+            ItemChannelLinkRegistry itemChannelLinkRegistry, HttpClientFactory httpClientFactory) {
+        super(thing, stateDescriptionProvider, itemChannelLinkRegistry);
+        lgThinqACApiClientService = LGThinQApiClientServiceFactory.newACApiClientService(lgPlatformType, httpClientFactory);
+        channelGroupDashboardUID = new ChannelGroupUID(getThing().getUID(), CHANNEL_DASHBOARD_GRP_ID);
+        channelGroupExtendedInfoUID = new ChannelGroupUID(getThing().getUID(), CHANNEL_EXTENDED_INFO_GRP_ID);
 
-		opModeChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_MOD_OP_ID);
-		targetTempChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_TARGET_TEMP_ID);
-		currTempChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_CURRENT_TEMP_ID);
-		fanSpeedChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_FAN_SPEED_ID);
-		jetModeChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_COOL_JET_ID);
-		airCleanChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_AIR_CLEAN_ID);
-		autoDryChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_AUTO_DRY_ID);
-		energySavingChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_ENERGY_SAVING_ID);
-		powerChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_POWER_ID);
-		extendedInfoCollectorChannelUID = new ChannelUID(channelGroupExtendedInfoUID,
-				CHANNEL_EXTENDED_INFO_COLLECTOR_ID);
-		currentPowerEnergyChannelUID = new ChannelUID(channelGroupExtendedInfoUID, CHANNEL_CURRENT_POWER_ID);
-		remainingFilterChannelUID = new ChannelUID(channelGroupExtendedInfoUID, CHANNEL_REMAINING_FILTER_ID);
-	}
+        opModeChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_MOD_OP_ID);
+        targetTempChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_TARGET_TEMP_ID);
+        currTempChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_CURRENT_TEMP_ID);
+        fanSpeedChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_FAN_SPEED_ID);
+        jetModeChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_COOL_JET_ID);
+        airCleanChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_AIR_CLEAN_ID);
+        autoDryChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_AUTO_DRY_ID);
+        energySavingChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_ENERGY_SAVING_ID);
+        powerChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_POWER_ID);
+        extendedInfoCollectorChannelUID = new ChannelUID(channelGroupExtendedInfoUID,
+                CHANNEL_EXTENDED_INFO_COLLECTOR_ID);
+        currentPowerEnergyChannelUID = new ChannelUID(channelGroupExtendedInfoUID, CHANNEL_CURRENT_POWER_ID);
+        remainingFilterChannelUID = new ChannelUID(channelGroupExtendedInfoUID, CHANNEL_REMAINING_FILTER_ID);
+    }
 
-	@Override
-	public void initialize() {
-		super.initialize();
-		try {
-			ACCapability cap = getCapabilities();
-			if (!isExtraInfoCollectorSupported()) {
-				ThingBuilder builder = editThing()
-						.withoutChannels(this.getThing().getChannelsOfGroup(channelGroupExtendedInfoUID.getId()));
-				updateThing(builder.build());
-			} else if (!cap.isEnergyMonitorAvailable()) {
-				ThingBuilder builder = editThing().withoutChannel(currentPowerEnergyChannelUID);
-				updateThing(builder.build());
-			} else if (!cap.isFilterMonitorAvailable()) {
-				ThingBuilder builder = editThing().withoutChannel(remainingFilterChannelUID);
-				updateThing(builder.build());
-			}
-		} catch (LGThinqApiException e) {
-			logger.warn("Error getting capability of the device:{}", getDeviceId());
+    @Override
+    public void initialize() {
+        super.initialize();
+        try {
+            ACCapability cap = getCapabilities();
+            if (!isExtraInfoCollectorSupported()) {
+                ThingBuilder builder = editThing()
+                        .withoutChannels(this.getThing().getChannelsOfGroup(channelGroupExtendedInfoUID.getId()));
+                updateThing(builder.build());
+            } else if (!cap.isEnergyMonitorAvailable()) {
+                ThingBuilder builder = editThing().withoutChannel(currentPowerEnergyChannelUID);
+                updateThing(builder.build());
+            } else if (!cap.isFilterMonitorAvailable()) {
+                ThingBuilder builder = editThing().withoutChannel(remainingFilterChannelUID);
+                updateThing(builder.build());
+            }
+        } catch (LGThinqApiException e) {
+			logger.warn("Error getting capability of the device: {}", getDeviceId());
+        }
+    }
+
+    @Override
+    protected void updateDeviceChannels(ACCanonicalSnapshot shot) {
+		logger.debug("Calling updateDeviceChannel for device: {}", getDeviceId());
+        updateState(powerChannelUID,
+                DevicePowerState.DV_POWER_ON.equals(shot.getPowerStatus()) ? OnOffType.ON : OnOffType.OFF);
+        updateState(opModeChannelUID, new DecimalType(BigDecimal.valueOf(shot.getOperationMode())));
+        updateState(fanSpeedChannelUID, new DecimalType(BigDecimal.valueOf(shot.getAirWindStrength())));
+        updateState(currTempChannelUID, new DecimalType(BigDecimal.valueOf(shot.getCurrentTemperature())));
+        updateState(targetTempChannelUID, new DecimalType(BigDecimal.valueOf(shot.getTargetTemperature())));
+        try {
+            ACCapability acCap = getCapabilities();
+            if (getThing().getChannel(jetModeChannelUID) != null) {
+                Double commandCoolJetOn = Double.valueOf(acCap.getCoolJetModeCommandOn());
+                updateState(jetModeChannelUID,
+                        commandCoolJetOn.equals(shot.getCoolJetMode()) ? OnOffType.ON : OnOffType.OFF);
+            }
+            if (getThing().getChannel(airCleanChannelUID) != null) {
+                Double commandAirCleanOn = Double.valueOf(acCap.getAirCleanModeCommandOn());
+                updateState(airCleanChannelUID,
+                        commandAirCleanOn.equals(shot.getAirCleanMode()) ? OnOffType.ON : OnOffType.OFF);
+            }
+            if (getThing().getChannel(energySavingChannelUID) != null) {
+                Double energySavingOn = Double.valueOf(acCap.getEnergySavingModeCommandOn());
+                updateState(energySavingChannelUID,
+                        energySavingOn.equals(shot.getEnergySavingMode()) ? OnOffType.ON : OnOffType.OFF);
+            }
+            if (getThing().getChannel(autoDryChannelUID) != null) {
+                Double autoDryOn = Double.valueOf(acCap.getCoolJetModeCommandOn());
+                updateState(autoDryChannelUID, autoDryOn.equals(shot.getAutoDryMode()) ? OnOffType.ON : OnOffType.OFF);
+            }
+
+        } catch (LGThinqApiException e) {
+            logger.error("Unexpected Error gettinf ACCapability Capabilities", e);
+        } catch (NumberFormatException e) {
+            logger.warn("command value for capability is not numeric.", e);
+        }
+    }
+
+    @Override
+    public void updateChannelDynStateDescription() throws LGThinqApiException {
+        ACCapability acCap = getCapabilities();
+        if (getThing().getChannel(jetModeChannelUID) == null && acCap.isJetModeAvailable()) {
+            createDynSwitchChannel(CHANNEL_COOL_JET_ID, jetModeChannelUID);
+        }
+        if (getThing().getChannel(autoDryChannelUID) == null && acCap.isAutoDryModeAvailable()) {
+            createDynSwitchChannel(CHANNEL_AUTO_DRY_ID, autoDryChannelUID);
+        }
+        if (getThing().getChannel(airCleanChannelUID) == null && acCap.isAirCleanAvailable()) {
+            createDynSwitchChannel(CHANNEL_AIR_CLEAN_ID, airCleanChannelUID);
+        }
+        if (getThing().getChannel(energySavingChannelUID) == null && acCap.isEnergySavingAvailable()) {
+            createDynSwitchChannel(CHANNEL_ENERGY_SAVING_ID, energySavingChannelUID);
+        }
+        if (!acCap.getFanSpeed().isEmpty()) {
+            List<StateOption> options = new ArrayList<>();
+            acCap.getFanSpeed()
+                    .forEach((k, v) -> options.add(new StateOption(k, emptyIfNull(CAP_AC_FAN_SPEED.get(v)))));
+            stateDescriptionProvider.setStateOptions(fanSpeedChannelUID, options);
+        }
+        if (!acCap.getOpMode().isEmpty()) {
+            List<StateOption> options = new ArrayList<>();
+            acCap.getOpMode().forEach((k, v) -> options.add(new StateOption(k, emptyIfNull(CAP_AC_OP_MODE.get(v)))));
+            stateDescriptionProvider.setStateOptions(opModeChannelUID, options);
+        }
+    }
+
+    @Override
+    public LGThinQApiClientService<ACCapability, ACCanonicalSnapshot> getLgThinQAPIClientService() {
+        return lgThinqACApiClientService;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return logger;
+    }
+
+    protected DeviceTypes getDeviceType() {
+        if (THING_TYPE_HEAT_PUMP.equals(getThing().getThingTypeUID())) {
+            return DeviceTypes.HEAT_PUMP;
+        } else if (THING_TYPE_AIR_CONDITIONER.equals(getThing().getThingTypeUID())) {
+            return DeviceTypes.AIR_CONDITIONER;
+        } else {
+            throw new IllegalArgumentException(
+                    "DeviceTypeUuid [" + getThing().getThingTypeUID() + "] not expected for AirConditioner/HeatPump");
+        }
+    }
+
+    @Override
+    public void onDeviceAdded(LGDevice device) {
+        // TODO - handle it. Think if it's needed
+    }
+
+    @Override
+    public String getDeviceAlias() {
+        return emptyIfNull(getThing().getProperties().get(DEVICE_ALIAS));
+    }
+
+    @Override
+    public String getDeviceUriJsonConfig() {
+        return emptyIfNull(getThing().getProperties().get(MODEL_URL_INFO));
+    }
+
+    @Override
+    public void onDeviceRemoved() {
+        // TODO - HANDLE IT, Think if it's needed
+    }
+
+    @Override
+    public void onDeviceDisconnected() {
+        // TODO - HANDLE IT, Think if it's needed
+    }
+
+    protected void resetExtraInfoChannels() {
+        updateState(currentPowerEnergyChannelUID, UnDefType.UNDEF);
+		if (!isExtraInfoCollectorEnabled()) { // if collector is enabled we can keep the current value
+		    updateState(remainingFilterChannelUID, UnDefType.UNDEF);
 		}
 	}
 
-	@Override
-	protected void updateDeviceChannels(ACCanonicalSnapshot shot) {
-		logger.debug("Calling updateDeviceChannel for device:{}", getDeviceAlias());
-		updateState(powerChannelUID,
-				DevicePowerState.DV_POWER_ON.equals(shot.getPowerStatus()) ? OnOffType.ON : OnOffType.OFF);
-		updateState(opModeChannelUID, new DecimalType(BigDecimal.valueOf(shot.getOperationMode())));
-		updateState(fanSpeedChannelUID, new DecimalType(BigDecimal.valueOf(shot.getAirWindStrength())));
-		updateState(currTempChannelUID, new DecimalType(BigDecimal.valueOf(shot.getCurrentTemperature())));
-		updateState(targetTempChannelUID, new DecimalType(BigDecimal.valueOf(shot.getTargetTemperature())));
-		try {
-			ACCapability acCap = getCapabilities();
-			if (getThing().getChannel(jetModeChannelUID) != null) {
-				Double commandCoolJetOn = Double.valueOf(acCap.getCoolJetModeCommandOn());
-				updateState(jetModeChannelUID,
-						commandCoolJetOn.equals(shot.getCoolJetMode()) ? OnOffType.ON : OnOffType.OFF);
-			}
-			if (getThing().getChannel(airCleanChannelUID) != null) {
-				Double commandAirCleanOn = Double.valueOf(acCap.getAirCleanModeCommandOn());
-				updateState(airCleanChannelUID,
-						commandAirCleanOn.equals(shot.getAirCleanMode()) ? OnOffType.ON : OnOffType.OFF);
-			}
-			if (getThing().getChannel(energySavingChannelUID) != null) {
-				Double energySavingOn = Double.valueOf(acCap.getEnergySavingModeCommandOn());
-				updateState(energySavingChannelUID,
-						energySavingOn.equals(shot.getEnergySavingMode()) ? OnOffType.ON : OnOffType.OFF);
-			}
-			if (getThing().getChannel(autoDryChannelUID) != null) {
-				Double autoDryOn = Double.valueOf(acCap.getCoolJetModeCommandOn());
-				updateState(autoDryChannelUID, autoDryOn.equals(shot.getAutoDryMode()) ? OnOffType.ON : OnOffType.OFF);
-			}
+    protected void processCommand(AsyncCommandParams params) throws LGThinqApiException {
+        Command command = params.command;
+        switch (getSimpleChannelUID(params.channelUID)) {
+            case CHANNEL_MOD_OP_ID: {
+                if (params.command instanceof DecimalType) {
+                    lgThinqACApiClientService.changeOperationMode(getBridgeId(), getDeviceId(),
+                            ((DecimalType) command).intValue());
+                } else {
+                    logger.warn("Received command different of Numeric in Mod Operation. Ignoring");
+                }
+                break;
+            }
+            case CHANNEL_FAN_SPEED_ID: {
+                if (command instanceof DecimalType) {
+                    lgThinqACApiClientService.changeFanSpeed(getBridgeId(), getDeviceId(),
+                            ((DecimalType) command).intValue());
+                } else {
+                    logger.warn("Received command different of Numeric in FanSpeed Channel. Ignoring");
+                }
+                break;
+            }
+            case CHANNEL_POWER_ID: {
+                if (command instanceof OnOffType) {
+                    lgThinqACApiClientService.turnDevicePower(getBridgeId(), getDeviceId(),
+                            command == OnOffType.ON ? DevicePowerState.DV_POWER_ON : DevicePowerState.DV_POWER_OFF);
+                } else {
+                    logger.warn("Received command different of OnOffType in Power Channel. Ignoring");
+                }
+                break;
+            }
+            case CHANNEL_COOL_JET_ID: {
+                if (command instanceof OnOffType) {
+                    lgThinqACApiClientService.turnCoolJetMode(getBridgeId(), getDeviceId(),
+                            command == OnOffType.ON ? getCapabilities().getCoolJetModeCommandOn()
+                                    : getCapabilities().getCoolJetModeCommandOff());
+                } else {
+                    logger.warn("Received command different of OnOffType in CoolJet Mode Channel. Ignoring");
+                }
+                break;
+            }
+            case CHANNEL_AIR_CLEAN_ID: {
+                if (command instanceof OnOffType) {
+                    lgThinqACApiClientService.turnAirCleanMode(getBridgeId(), getDeviceId(),
+                            command == OnOffType.ON ? getCapabilities().getAirCleanModeCommandOn()
+                                    : getCapabilities().getAirCleanModeCommandOff());
+                } else {
+                    logger.warn("Received command different of OnOffType in AirClean Mode Channel. Ignoring");
+                }
+                break;
+            }
+            case CHANNEL_AUTO_DRY_ID: {
+                if (command instanceof OnOffType) {
+                    lgThinqACApiClientService.turnAutoDryMode(getBridgeId(), getDeviceId(),
+                            command == OnOffType.ON ? getCapabilities().getAutoDryModeCommandOn()
+                                    : getCapabilities().getAutoDryModeCommandOff());
+                } else {
+                    logger.warn("Received command different of OnOffType in AutoDry Mode Channel. Ignoring");
+                }
+                break;
+            }
+            case CHANNEL_ENERGY_SAVING_ID: {
+                if (command instanceof OnOffType) {
+                    lgThinqACApiClientService.turnEnergySavingMode(getBridgeId(), getDeviceId(),
+                            command == OnOffType.ON ? getCapabilities().getEnergySavingModeCommandOn()
+                                    : getCapabilities().getEnergySavingModeCommandOff());
+                } else {
+                    logger.warn("Received command different of OnOffType in EvergySaving Mode Channel. Ignoring");
+                }
+                break;
+            }
+            case CHANNEL_TARGET_TEMP_ID: {
+                double targetTemp;
+                if (command instanceof DecimalType) {
+                    targetTemp = ((DecimalType) command).doubleValue();
+                } else if (command instanceof QuantityType) {
+                    targetTemp = ((QuantityType<?>) command).doubleValue();
+                } else {
+                    logger.warn("Received command different of Numeric in TargetTemp Channel. Ignoring");
+                    break;
+                }
+                lgThinqACApiClientService.changeTargetTemperature(getBridgeId(), getDeviceId(),
+                        ACTargetTmp.statusOf(targetTemp));
+                break;
+            }
+            case CHANNEL_EXTENDED_INFO_COLLECTOR_ID: {
+                break;
+            }
+            default: {
+                logger.error("Command {} to the channel {} not supported. Ignored.", command, params.channelUID);
+            }
+        }
+    }
+    // =========== Energy Colletor Implementation =============
 
-		} catch (LGThinqApiException e) {
-			logger.error("Unexpected Error gettinf ACCapability Capabilities", e);
-		} catch (NumberFormatException e) {
-			logger.warn("command value for capability is not numeric.", e);
-		}
-	}
-
-	@Override
-	public void updateChannelDynStateDescription() throws LGThinqApiException {
-		ACCapability acCap = getCapabilities();
-		if (getThing().getChannel(jetModeChannelUID) == null && acCap.isJetModeAvailable()) {
-			createDynSwitchChannel(CHANNEL_COOL_JET_ID, jetModeChannelUID);
-		}
-		if (getThing().getChannel(autoDryChannelUID) == null && acCap.isAutoDryModeAvailable()) {
-			createDynSwitchChannel(CHANNEL_AUTO_DRY_ID, autoDryChannelUID);
-		}
-		if (getThing().getChannel(airCleanChannelUID) == null && acCap.isAirCleanAvailable()) {
-			createDynSwitchChannel(CHANNEL_AIR_CLEAN_ID, airCleanChannelUID);
-		}
-		if (getThing().getChannel(energySavingChannelUID) == null && acCap.isEnergySavingAvailable()) {
-			createDynSwitchChannel(CHANNEL_ENERGY_SAVING_ID, energySavingChannelUID);
-		}
-		if (!acCap.getFanSpeed().isEmpty()) {
-			List<StateOption> options = new ArrayList<>();
-			acCap.getFanSpeed()
-					.forEach((k, v) -> options.add(new StateOption(k, emptyIfNull(CAP_AC_FAN_SPEED.get(v)))));
-			stateDescriptionProvider.setStateOptions(fanSpeedChannelUID, options);
-		}
-		if (!acCap.getOpMode().isEmpty()) {
-			List<StateOption> options = new ArrayList<>();
-			acCap.getOpMode().forEach((k, v) -> options.add(new StateOption(k, emptyIfNull(CAP_AC_OP_MODE.get(v)))));
-			stateDescriptionProvider.setStateOptions(opModeChannelUID, options);
-		}
-	}
-
-	@Override
-	public LGThinQApiClientService<ACCapability, ACCanonicalSnapshot> getLgThinQAPIClientService() {
-		return lgThinqACApiClientService;
-	}
-
-	@Override
-	protected Logger getLogger() {
-		return logger;
-	}
-
-	protected DeviceTypes getDeviceType() {
-		if (THING_TYPE_HEAT_PUMP.equals(getThing().getThingTypeUID())) {
-			return DeviceTypes.HEAT_PUMP;
-		} else if (THING_TYPE_AIR_CONDITIONER.equals(getThing().getThingTypeUID())) {
-			return DeviceTypes.AIR_CONDITIONER;
-		} else {
-			throw new IllegalArgumentException(
-					"DeviceTypeUuid [" + getThing().getThingTypeUID() + "] not expected for AirConditioner/HeatPump");
-		}
-	}
-
-	@Override
-	public void onDeviceAdded(LGDevice device) {
-		// TODO - handle it. Think if it's needed
-	}
-
-	@Override
-	public String getDeviceAlias() {
-		return emptyIfNull(getThing().getProperties().get(DEVICE_ALIAS));
-	}
-
-	@Override
-	public String getDeviceUriJsonConfig() {
-		return emptyIfNull(getThing().getProperties().get(MODEL_URL_INFO));
-	}
-
-	@Override
-	public void onDeviceRemoved() {
-		// TODO - HANDLE IT, Think if it's needed
-	}
-
-	@Override
-	public void onDeviceDisconnected() {
-		// TODO - HANDLE IT, Think if it's needed
-	}
-
-	protected void resetExtraInfoChannels() {
-		updateState(currentPowerEnergyChannelUID, UnDefType.UNDEF);
-		updateState(remainingFilterChannelUID, UnDefType.UNDEF);
-	}
-
-	protected void processCommand(AsyncCommandParams params) throws LGThinqApiException {
-		Command command = params.command;
-		switch (getSimpleChannelUID(params.channelUID)) {
-			case CHANNEL_MOD_OP_ID: {
-				if (params.command instanceof DecimalType) {
-					lgThinqACApiClientService.changeOperationMode(getBridgeId(), getDeviceId(),
-							((DecimalType) command).intValue());
-				} else {
-					logger.warn("Received command different of Numeric in Mod Operation. Ignoring");
-				}
-				break;
-			}
-			case CHANNEL_FAN_SPEED_ID: {
-				if (command instanceof DecimalType) {
-					lgThinqACApiClientService.changeFanSpeed(getBridgeId(), getDeviceId(),
-							((DecimalType) command).intValue());
-				} else {
-					logger.warn("Received command different of Numeric in FanSpeed Channel. Ignoring");
-				}
-				break;
-			}
-			case CHANNEL_POWER_ID: {
-				if (command instanceof OnOffType) {
-					lgThinqACApiClientService.turnDevicePower(getBridgeId(), getDeviceId(),
-							command == OnOffType.ON ? DevicePowerState.DV_POWER_ON : DevicePowerState.DV_POWER_OFF);
-				} else {
-					logger.warn("Received command different of OnOffType in Power Channel. Ignoring");
-				}
-				break;
-			}
-			case CHANNEL_COOL_JET_ID: {
-				if (command instanceof OnOffType) {
-					lgThinqACApiClientService.turnCoolJetMode(getBridgeId(), getDeviceId(),
-							command == OnOffType.ON ? getCapabilities().getCoolJetModeCommandOn()
-									: getCapabilities().getCoolJetModeCommandOff());
-				} else {
-					logger.warn("Received command different of OnOffType in CoolJet Mode Channel. Ignoring");
-				}
-				break;
-			}
-			case CHANNEL_AIR_CLEAN_ID: {
-				if (command instanceof OnOffType) {
-					lgThinqACApiClientService.turnAirCleanMode(getBridgeId(), getDeviceId(),
-							command == OnOffType.ON ? getCapabilities().getAirCleanModeCommandOn()
-									: getCapabilities().getAirCleanModeCommandOff());
-				} else {
-					logger.warn("Received command different of OnOffType in AirClean Mode Channel. Ignoring");
-				}
-				break;
-			}
-			case CHANNEL_AUTO_DRY_ID: {
-				if (command instanceof OnOffType) {
-					lgThinqACApiClientService.turnAutoDryMode(getBridgeId(), getDeviceId(),
-							command == OnOffType.ON ? getCapabilities().getAutoDryModeCommandOn()
-									: getCapabilities().getAutoDryModeCommandOff());
-				} else {
-					logger.warn("Received command different of OnOffType in AutoDry Mode Channel. Ignoring");
-				}
-				break;
-			}
-			case CHANNEL_ENERGY_SAVING_ID: {
-				if (command instanceof OnOffType) {
-					lgThinqACApiClientService.turnEnergySavingMode(getBridgeId(), getDeviceId(),
-							command == OnOffType.ON ? getCapabilities().getEnergySavingModeCommandOn()
-									: getCapabilities().getEnergySavingModeCommandOff());
-				} else {
-					logger.warn("Received command different of OnOffType in EvergySaving Mode Channel. Ignoring");
-				}
-				break;
-			}
-			case CHANNEL_TARGET_TEMP_ID: {
-				double targetTemp;
-				if (command instanceof DecimalType) {
-					targetTemp = ((DecimalType) command).doubleValue();
-				} else if (command instanceof QuantityType) {
-					targetTemp = ((QuantityType<?>) command).doubleValue();
-				} else {
-					logger.warn("Received command different of Numeric in TargetTemp Channel. Ignoring");
-					break;
-				}
-				lgThinqACApiClientService.changeTargetTemperature(getBridgeId(), getDeviceId(),
-						ACTargetTmp.statusOf(targetTemp));
-				break;
-			}
-			case CHANNEL_EXTENDED_INFO_COLLECTOR_ID: {
-				break;
-			}
-			default: {
-				logger.error("Command {} to the channel {} not supported. Ignored.", command, params.channelUID);
-			}
-		}
-	}
-	// =========== Energy Colletor Implementation =============
-
-	@Override
-	protected boolean isExtraInfoCollectorSupported() {
-		try {
-			return getCapabilities().isEnergyMonitorAvailable() || getCapabilities().isFilterMonitorAvailable();
-		} catch (LGThinqApiException e) {
+    @Override
+    protected boolean isExtraInfoCollectorSupported() {
+        try {
+            return getCapabilities().isEnergyMonitorAvailable() || getCapabilities().isFilterMonitorAvailable();
+        } catch (LGThinqApiException e) {
 			logger.warn("Can't get capabilities of the device: {}", getDeviceId());
-		}
-		return false;
-	}
+        }
+        return false;
+    }
 
-	@Override
-	protected boolean isExtraInfoCollectorEnabled() {
-		return OnOffType.ON.toString().equals(getItemLinkedValue(extendedInfoCollectorChannelUID));
-	}
+    @Override
+    protected boolean isExtraInfoCollectorEnabled() {
+        return OnOffType.ON.toString().equals(getItemLinkedValue(extendedInfoCollectorChannelUID));
+    }
 
-	@Override
-	protected Map<String, Object> collectExtraInfoState() throws LGThinqException {
-		ExtendedDeviceInfo info = lgThinqACApiClientService.getExtendedDeviceInfo(getBridgeId(), getDeviceId());
-		return mapper.convertValue(info, new TypeReference<>() {
-		});
-	}
+    @Override
+    protected Map<String, Object> collectExtraInfoState() throws LGThinqException {
+        ExtendedDeviceInfo info = lgThinqACApiClientService.getExtendedDeviceInfo(getBridgeId(), getDeviceId());
+        return mapper.convertValue(info, new TypeReference<>() {
+        });
+    }
 
-	@Override
-	protected void updateExtraInfoStateChannels(Map<String, Object> energyStateAttributes) throws LGThinqException {
-		logger.debug("Calling updateExtraInfoStateChannels for device:{}", getDeviceAlias());
-		String instantPowerConsumption = (String) energyStateAttributes.get(EXTENDED_ATTR_INSTANT_POWER);
-		String filterUsed = (String) energyStateAttributes.get(EXTENDED_ATTR_FILTER_USED_TIME);
-		String filterTimelife = (String) energyStateAttributes.get(EXTENDED_ATTR_FILTER_MAX_TIME_TO_USE);
-		if (instantPowerConsumption == null) {
-			updateState(currentPowerEnergyChannelUID, UnDefType.NULL);
-		} else if (NumberUtils.isCreatable(instantPowerConsumption)) {
-			double ip = Double.parseDouble(instantPowerConsumption);
-			updateState(currentPowerEnergyChannelUID, new QuantityType<>(ip, Units.WATT));
-		} else {
-			updateState(currentPowerEnergyChannelUID, UnDefType.UNDEF);
-		}
+    @Override
+    protected void updateExtraInfoStateChannels(Map<String, Object> energyStateAttributes) throws LGThinqException {
+		logger.debug("Calling updateExtraInfoStateChannels for device: {}", getDeviceId());
+        String instantPowerConsumption = (String) energyStateAttributes.get(EXTENDED_ATTR_INSTANT_POWER);
+        String filterUsed = (String) energyStateAttributes.get(EXTENDED_ATTR_FILTER_USED_TIME);
+        String filterTimelife = (String) energyStateAttributes.get(EXTENDED_ATTR_FILTER_MAX_TIME_TO_USE);
+        if (instantPowerConsumption == null) {
+            updateState(currentPowerEnergyChannelUID, UnDefType.NULL);
+        } else if (NumberUtils.isCreatable(instantPowerConsumption)) {
+            double ip = Double.parseDouble(instantPowerConsumption);
+            updateState(currentPowerEnergyChannelUID, new QuantityType<>(ip, Units.WATT));
+        } else {
+            updateState(currentPowerEnergyChannelUID, UnDefType.UNDEF);
+        }
 
-		if (filterTimelife == null || filterUsed == null) {
-			updateState(remainingFilterChannelUID, UnDefType.NULL);
-		} else if (NumberUtils.isCreatable(filterTimelife) && NumberUtils.isCreatable(filterUsed)) {
-			double used = Double.parseDouble(filterUsed);
-			double max = Double.parseDouble(filterTimelife);
+        if (filterTimelife == null || filterUsed == null) {
+            updateState(remainingFilterChannelUID, UnDefType.NULL);
+        } else if (NumberUtils.isCreatable(filterTimelife) && NumberUtils.isCreatable(filterUsed)) {
+            double used = Double.parseDouble(filterUsed);
+            double max = Double.parseDouble(filterTimelife);
             double perc = (1 - ((double) used / max)) * 100;
-			updateState(remainingFilterChannelUID, new QuantityType<>(perc, Units.PERCENT));
-		} else {
-			updateState(remainingFilterChannelUID, UnDefType.UNDEF);
-		}
-	}
+            updateState(remainingFilterChannelUID, new QuantityType<>(perc, Units.PERCENT));
+        } else {
+            updateState(remainingFilterChannelUID, UnDefType.UNDEF);
+        }
+    }
 }

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/handler/LGThinQAirConditionerHandler.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/handler/LGThinQAirConditionerHandler.java
@@ -25,9 +25,8 @@ import org.openhab.binding.lgthinq.internal.LGThinQStateDescriptionProvider;
 import org.openhab.binding.lgthinq.internal.errors.LGThinqApiException;
 import org.openhab.binding.lgthinq.internal.errors.LGThinqException;
 import org.openhab.binding.lgthinq.lgservices.LGThinQACApiClientService;
-import org.openhab.binding.lgthinq.lgservices.LGThinQACApiV1ClientServiceImpl;
-import org.openhab.binding.lgthinq.lgservices.LGThinQACApiV2ClientServiceImpl;
 import org.openhab.binding.lgthinq.lgservices.LGThinQApiClientService;
+import org.openhab.binding.lgthinq.lgservices.LGThinQApiClientServiceFactory;
 import org.openhab.binding.lgthinq.lgservices.model.DevicePowerState;
 import org.openhab.binding.lgthinq.lgservices.model.DeviceTypes;
 import org.openhab.binding.lgthinq.lgservices.model.LGDevice;
@@ -35,11 +34,11 @@ import org.openhab.binding.lgthinq.lgservices.model.devices.ac.ACCanonicalSnapsh
 import org.openhab.binding.lgthinq.lgservices.model.devices.ac.ACCapability;
 import org.openhab.binding.lgthinq.lgservices.model.devices.ac.ACTargetTmp;
 import org.openhab.binding.lgthinq.lgservices.model.devices.ac.ExtendedDeviceInfo;
+import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
-import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelGroupUID;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -63,329 +62,326 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @NonNullByDefault
 public class LGThinQAirConditionerHandler extends LGThinQAbstractDeviceHandler<ACCapability, ACCanonicalSnapshot> {
 
-    public final ChannelGroupUID channelGroupExtendedInfoUID;
-    public final ChannelGroupUID channelGroupDashboardUID;
-    private final ChannelUID powerChannelUID;
-    private final ChannelUID opModeChannelUID;
-    private final ChannelUID fanSpeedChannelUID;
-    private final ChannelUID targetTempChannelUID;
-    private final ChannelUID currTempChannelUID;
-    private final ChannelUID jetModeChannelUID;
-    private final ChannelUID airCleanChannelUID;
-    private final ChannelUID autoDryChannelUID;
-    private final ChannelUID energySavingChannelUID;
-    private final ChannelUID extendedInfoCollectorChannelUID;
-    private final ChannelUID currentPowerEnergyChannelUID;
-    private final ChannelUID remainingFilterChannelUID;
+	public final ChannelGroupUID channelGroupExtendedInfoUID;
+	public final ChannelGroupUID channelGroupDashboardUID;
+	private final ChannelUID powerChannelUID;
+	private final ChannelUID opModeChannelUID;
+	private final ChannelUID fanSpeedChannelUID;
+	private final ChannelUID targetTempChannelUID;
+	private final ChannelUID currTempChannelUID;
+	private final ChannelUID jetModeChannelUID;
+	private final ChannelUID airCleanChannelUID;
+	private final ChannelUID autoDryChannelUID;
+	private final ChannelUID energySavingChannelUID;
+	private final ChannelUID extendedInfoCollectorChannelUID;
+	private final ChannelUID currentPowerEnergyChannelUID;
+	private final ChannelUID remainingFilterChannelUID;
 
-    private final ObjectMapper mapper = new ObjectMapper();
-    private final Logger logger = LoggerFactory.getLogger(LGThinQAirConditionerHandler.class);
-    @NonNullByDefault
-    private final LGThinQACApiClientService lgThinqACApiClientService;
+	private final ObjectMapper mapper = new ObjectMapper();
+	private final Logger logger = LoggerFactory.getLogger(LGThinQAirConditionerHandler.class);
+	@NonNullByDefault
+	private final LGThinQACApiClientService lgThinqACApiClientService;
 
-    public LGThinQAirConditionerHandler(Thing thing, LGThinQStateDescriptionProvider stateDescriptionProvider,
-            ItemChannelLinkRegistry itemChannelLinkRegistry) {
-        super(thing, stateDescriptionProvider, itemChannelLinkRegistry);
-        lgThinqACApiClientService = lgPlatformType.equals(PLATFORM_TYPE_V1)
-                ? LGThinQACApiV1ClientServiceImpl.getInstance()
-                : LGThinQACApiV2ClientServiceImpl.getInstance();
-        channelGroupDashboardUID = new ChannelGroupUID(getThing().getUID(), CHANNEL_DASHBOARD_GRP_ID);
-        channelGroupExtendedInfoUID = new ChannelGroupUID(getThing().getUID(), CHANNEL_EXTENDED_INFO_GRP_ID);
+	public LGThinQAirConditionerHandler(Thing thing, LGThinQStateDescriptionProvider stateDescriptionProvider,
+			ItemChannelLinkRegistry itemChannelLinkRegistry, HttpClientFactory httpClientFactory) {
+		super(thing, stateDescriptionProvider, itemChannelLinkRegistry);
+		lgThinqACApiClientService = LGThinQApiClientServiceFactory.newACApiClientService(lgPlatformType, httpClientFactory);
+		channelGroupDashboardUID = new ChannelGroupUID(getThing().getUID(), CHANNEL_DASHBOARD_GRP_ID);
+		channelGroupExtendedInfoUID = new ChannelGroupUID(getThing().getUID(), CHANNEL_EXTENDED_INFO_GRP_ID);
 
-        opModeChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_MOD_OP_ID);
-        targetTempChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_TARGET_TEMP_ID);
-        currTempChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_CURRENT_TEMP_ID);
-        fanSpeedChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_FAN_SPEED_ID);
-        jetModeChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_COOL_JET_ID);
-        airCleanChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_AIR_CLEAN_ID);
-        autoDryChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_AUTO_DRY_ID);
-        energySavingChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_ENERGY_SAVING_ID);
-        powerChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_POWER_ID);
-        extendedInfoCollectorChannelUID = new ChannelUID(channelGroupExtendedInfoUID,
-                CHANNEL_EXTENDED_INFO_COLLECTOR_ID);
-        currentPowerEnergyChannelUID = new ChannelUID(channelGroupExtendedInfoUID, CHANNEL_CURRENT_POWER_ID);
-        remainingFilterChannelUID = new ChannelUID(channelGroupExtendedInfoUID, CHANNEL_REMAINING_FILTER_ID);
-    }
+		opModeChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_MOD_OP_ID);
+		targetTempChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_TARGET_TEMP_ID);
+		currTempChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_CURRENT_TEMP_ID);
+		fanSpeedChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_FAN_SPEED_ID);
+		jetModeChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_COOL_JET_ID);
+		airCleanChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_AIR_CLEAN_ID);
+		autoDryChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_AUTO_DRY_ID);
+		energySavingChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_ENERGY_SAVING_ID);
+		powerChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_POWER_ID);
+		extendedInfoCollectorChannelUID = new ChannelUID(channelGroupExtendedInfoUID,
+				CHANNEL_EXTENDED_INFO_COLLECTOR_ID);
+		currentPowerEnergyChannelUID = new ChannelUID(channelGroupExtendedInfoUID, CHANNEL_CURRENT_POWER_ID);
+		remainingFilterChannelUID = new ChannelUID(channelGroupExtendedInfoUID, CHANNEL_REMAINING_FILTER_ID);
+	}
 
-    @Override
-    public void initialize() {
-    	super.initialize();
-        try {
-            ACCapability cap = getCapabilities();
-            if (!isExtraInfoCollectorSupported()) {
-                ThingBuilder builder = editThing()
-                        .withoutChannels(this.getThing().getChannelsOfGroup(channelGroupExtendedInfoUID.getId()));
-                updateThing(builder.build());
-            } else if (!cap.isEnergyMonitorAvailable()) {
-                ThingBuilder builder = editThing().withoutChannel(currentPowerEnergyChannelUID);
-                updateThing(builder.build());
-            } else if (!cap.isFilterMonitorAvailable()) {
-                ThingBuilder builder = editThing().withoutChannel(remainingFilterChannelUID);
-                updateThing(builder.build());
-            }
-        } catch (LGThinqApiException e) {
-            logger.warn("Error getting capability of the device:{}", getDeviceId());
-        }
-    }
+	@Override
+	public void initialize() {
+		super.initialize();
+		try {
+			ACCapability cap = getCapabilities();
+			if (!isExtraInfoCollectorSupported()) {
+				ThingBuilder builder = editThing()
+						.withoutChannels(this.getThing().getChannelsOfGroup(channelGroupExtendedInfoUID.getId()));
+				updateThing(builder.build());
+			} else if (!cap.isEnergyMonitorAvailable()) {
+				ThingBuilder builder = editThing().withoutChannel(currentPowerEnergyChannelUID);
+				updateThing(builder.build());
+			} else if (!cap.isFilterMonitorAvailable()) {
+				ThingBuilder builder = editThing().withoutChannel(remainingFilterChannelUID);
+				updateThing(builder.build());
+			}
+		} catch (LGThinqApiException e) {
+			logger.warn("Error getting capability of the device:{}", getDeviceId());
+		}
+	}
 
-    @Override
-    protected void updateDeviceChannels(ACCanonicalSnapshot shot) {
-        logger.debug("Calling updateDeviceChannel for device:{}", getDeviceAlias());
-        updateState(powerChannelUID,
-                DevicePowerState.DV_POWER_ON.equals(shot.getPowerStatus()) ? OnOffType.ON : OnOffType.OFF);
-        updateState(opModeChannelUID, new DecimalType(BigDecimal.valueOf(shot.getOperationMode())));
-        updateState(fanSpeedChannelUID, new DecimalType(BigDecimal.valueOf(shot.getAirWindStrength())));
-        updateState(currTempChannelUID, new DecimalType(BigDecimal.valueOf(shot.getCurrentTemperature())));
-        updateState(targetTempChannelUID, new DecimalType(BigDecimal.valueOf(shot.getTargetTemperature())));
-        try {
-            ACCapability acCap = getCapabilities();
-            if (getThing().getChannel(jetModeChannelUID) != null) {
-                Double commandCoolJetOn = Double.valueOf(acCap.getCoolJetModeCommandOn());
-                updateState(jetModeChannelUID,
-                        commandCoolJetOn.equals(shot.getCoolJetMode()) ? OnOffType.ON : OnOffType.OFF);
-            }
-            if (getThing().getChannel(airCleanChannelUID) != null) {
-                Double commandAirCleanOn = Double.valueOf(acCap.getAirCleanModeCommandOn());
-                updateState(airCleanChannelUID,
-                        commandAirCleanOn.equals(shot.getAirCleanMode()) ? OnOffType.ON : OnOffType.OFF);
-            }
-            if (getThing().getChannel(energySavingChannelUID) != null) {
-                Double energySavingOn = Double.valueOf(acCap.getEnergySavingModeCommandOn());
-                updateState(energySavingChannelUID,
-                        energySavingOn.equals(shot.getEnergySavingMode()) ? OnOffType.ON : OnOffType.OFF);
-            }
-            if (getThing().getChannel(autoDryChannelUID) != null) {
-                Double autoDryOn = Double.valueOf(acCap.getCoolJetModeCommandOn());
-                updateState(autoDryChannelUID, autoDryOn.equals(shot.getAutoDryMode()) ? OnOffType.ON : OnOffType.OFF);
-            }
+	@Override
+	protected void updateDeviceChannels(ACCanonicalSnapshot shot) {
+		logger.debug("Calling updateDeviceChannel for device:{}", getDeviceAlias());
+		updateState(powerChannelUID,
+				DevicePowerState.DV_POWER_ON.equals(shot.getPowerStatus()) ? OnOffType.ON : OnOffType.OFF);
+		updateState(opModeChannelUID, new DecimalType(BigDecimal.valueOf(shot.getOperationMode())));
+		updateState(fanSpeedChannelUID, new DecimalType(BigDecimal.valueOf(shot.getAirWindStrength())));
+		updateState(currTempChannelUID, new DecimalType(BigDecimal.valueOf(shot.getCurrentTemperature())));
+		updateState(targetTempChannelUID, new DecimalType(BigDecimal.valueOf(shot.getTargetTemperature())));
+		try {
+			ACCapability acCap = getCapabilities();
+			if (getThing().getChannel(jetModeChannelUID) != null) {
+				Double commandCoolJetOn = Double.valueOf(acCap.getCoolJetModeCommandOn());
+				updateState(jetModeChannelUID,
+						commandCoolJetOn.equals(shot.getCoolJetMode()) ? OnOffType.ON : OnOffType.OFF);
+			}
+			if (getThing().getChannel(airCleanChannelUID) != null) {
+				Double commandAirCleanOn = Double.valueOf(acCap.getAirCleanModeCommandOn());
+				updateState(airCleanChannelUID,
+						commandAirCleanOn.equals(shot.getAirCleanMode()) ? OnOffType.ON : OnOffType.OFF);
+			}
+			if (getThing().getChannel(energySavingChannelUID) != null) {
+				Double energySavingOn = Double.valueOf(acCap.getEnergySavingModeCommandOn());
+				updateState(energySavingChannelUID,
+						energySavingOn.equals(shot.getEnergySavingMode()) ? OnOffType.ON : OnOffType.OFF);
+			}
+			if (getThing().getChannel(autoDryChannelUID) != null) {
+				Double autoDryOn = Double.valueOf(acCap.getCoolJetModeCommandOn());
+				updateState(autoDryChannelUID, autoDryOn.equals(shot.getAutoDryMode()) ? OnOffType.ON : OnOffType.OFF);
+			}
 
-        } catch (LGThinqApiException e) {
-            logger.error("Unexpected Error gettinf ACCapability Capabilities", e);
-        } catch (NumberFormatException e) {
-            logger.warn("command value for capability is not numeric.", e);
-        }
-    }
+		} catch (LGThinqApiException e) {
+			logger.error("Unexpected Error gettinf ACCapability Capabilities", e);
+		} catch (NumberFormatException e) {
+			logger.warn("command value for capability is not numeric.", e);
+		}
+	}
 
-    @Override
-    public void updateChannelDynStateDescription() throws LGThinqApiException {
-        ACCapability acCap = getCapabilities();
-        if (getThing().getChannel(jetModeChannelUID) == null && acCap.isJetModeAvailable()) {
-            createDynSwitchChannel(CHANNEL_COOL_JET_ID, jetModeChannelUID);
-        }
-        if (getThing().getChannel(autoDryChannelUID) == null && acCap.isAutoDryModeAvailable()) {
-            createDynSwitchChannel(CHANNEL_AUTO_DRY_ID, autoDryChannelUID);
-        }
-        if (getThing().getChannel(airCleanChannelUID) == null && acCap.isAirCleanAvailable()) {
-            createDynSwitchChannel(CHANNEL_AIR_CLEAN_ID, airCleanChannelUID);
-        }
-        if (getThing().getChannel(energySavingChannelUID) == null && acCap.isEnergySavingAvailable()) {
-            createDynSwitchChannel(CHANNEL_ENERGY_SAVING_ID, energySavingChannelUID);
-        }
-        if (!acCap.getFanSpeed().isEmpty()) {
-            List<StateOption> options = new ArrayList<>();
-            acCap.getFanSpeed()
-                    .forEach((k, v) -> options.add(new StateOption(k, emptyIfNull(CAP_AC_FAN_SPEED.get(v)))));
-            stateDescriptionProvider.setStateOptions(fanSpeedChannelUID, options);
-        }
-        if (!acCap.getOpMode().isEmpty()) {
-            List<StateOption> options = new ArrayList<>();
-            acCap.getOpMode().forEach((k, v) -> options.add(new StateOption(k, emptyIfNull(CAP_AC_OP_MODE.get(v)))));
-            stateDescriptionProvider.setStateOptions(opModeChannelUID, options);
-        }
-    }
+	@Override
+	public void updateChannelDynStateDescription() throws LGThinqApiException {
+		ACCapability acCap = getCapabilities();
+		if (getThing().getChannel(jetModeChannelUID) == null && acCap.isJetModeAvailable()) {
+			createDynSwitchChannel(CHANNEL_COOL_JET_ID, jetModeChannelUID);
+		}
+		if (getThing().getChannel(autoDryChannelUID) == null && acCap.isAutoDryModeAvailable()) {
+			createDynSwitchChannel(CHANNEL_AUTO_DRY_ID, autoDryChannelUID);
+		}
+		if (getThing().getChannel(airCleanChannelUID) == null && acCap.isAirCleanAvailable()) {
+			createDynSwitchChannel(CHANNEL_AIR_CLEAN_ID, airCleanChannelUID);
+		}
+		if (getThing().getChannel(energySavingChannelUID) == null && acCap.isEnergySavingAvailable()) {
+			createDynSwitchChannel(CHANNEL_ENERGY_SAVING_ID, energySavingChannelUID);
+		}
+		if (!acCap.getFanSpeed().isEmpty()) {
+			List<StateOption> options = new ArrayList<>();
+			acCap.getFanSpeed()
+					.forEach((k, v) -> options.add(new StateOption(k, emptyIfNull(CAP_AC_FAN_SPEED.get(v)))));
+			stateDescriptionProvider.setStateOptions(fanSpeedChannelUID, options);
+		}
+		if (!acCap.getOpMode().isEmpty()) {
+			List<StateOption> options = new ArrayList<>();
+			acCap.getOpMode().forEach((k, v) -> options.add(new StateOption(k, emptyIfNull(CAP_AC_OP_MODE.get(v)))));
+			stateDescriptionProvider.setStateOptions(opModeChannelUID, options);
+		}
+	}
 
-    @Override
-    public LGThinQApiClientService<ACCapability, ACCanonicalSnapshot> getLgThinQAPIClientService() {
-        return lgThinqACApiClientService;
-    }
+	@Override
+	public LGThinQApiClientService<ACCapability, ACCanonicalSnapshot> getLgThinQAPIClientService() {
+		return lgThinqACApiClientService;
+	}
 
-    @Override
-    protected Logger getLogger() {
-        return logger;
-    }
+	@Override
+	protected Logger getLogger() {
+		return logger;
+	}
 
-    protected DeviceTypes getDeviceType() {
-        if (THING_TYPE_HEAT_PUMP.equals(getThing().getThingTypeUID())) {
-            return DeviceTypes.HEAT_PUMP;
-        } else if (THING_TYPE_AIR_CONDITIONER.equals(getThing().getThingTypeUID())) {
-            return DeviceTypes.AIR_CONDITIONER;
-        } else {
-            throw new IllegalArgumentException(
-                    "DeviceTypeUuid [" + getThing().getThingTypeUID() + "] not expected for AirConditioner/HeatPump");
-        }
-    }
+	protected DeviceTypes getDeviceType() {
+		if (THING_TYPE_HEAT_PUMP.equals(getThing().getThingTypeUID())) {
+			return DeviceTypes.HEAT_PUMP;
+		} else if (THING_TYPE_AIR_CONDITIONER.equals(getThing().getThingTypeUID())) {
+			return DeviceTypes.AIR_CONDITIONER;
+		} else {
+			throw new IllegalArgumentException(
+					"DeviceTypeUuid [" + getThing().getThingTypeUID() + "] not expected for AirConditioner/HeatPump");
+		}
+	}
 
-    @Override
-    public void onDeviceAdded(LGDevice device) {
-        // TODO - handle it. Think if it's needed
-    }
+	@Override
+	public void onDeviceAdded(LGDevice device) {
+		// TODO - handle it. Think if it's needed
+	}
 
-    @Override
-    public String getDeviceAlias() {
-        return emptyIfNull(getThing().getProperties().get(DEVICE_ALIAS));
-    }
+	@Override
+	public String getDeviceAlias() {
+		return emptyIfNull(getThing().getProperties().get(DEVICE_ALIAS));
+	}
 
-    @Override
-    public String getDeviceUriJsonConfig() {
-        return emptyIfNull(getThing().getProperties().get(MODEL_URL_INFO));
-    }
+	@Override
+	public String getDeviceUriJsonConfig() {
+		return emptyIfNull(getThing().getProperties().get(MODEL_URL_INFO));
+	}
 
-    @Override
-    public void onDeviceRemoved() {
-        // TODO - HANDLE IT, Think if it's needed
-    }
+	@Override
+	public void onDeviceRemoved() {
+		// TODO - HANDLE IT, Think if it's needed
+	}
 
-    @Override
-    public void onDeviceDisconnected() {
-        // TODO - HANDLE IT, Think if it's needed
-    }
+	@Override
+	public void onDeviceDisconnected() {
+		// TODO - HANDLE IT, Think if it's needed
+	}
 
-    protected void resetExtraInfoChannels() {
-        updateState(currentPowerEnergyChannelUID, UnDefType.UNDEF);
-        updateState(remainingFilterChannelUID, UnDefType.UNDEF);
-    }
+	protected void resetExtraInfoChannels() {
+		updateState(currentPowerEnergyChannelUID, UnDefType.UNDEF);
+		updateState(remainingFilterChannelUID, UnDefType.UNDEF);
+	}
 
-    protected void processCommand(AsyncCommandParams params) throws LGThinqApiException {
-        Command command = params.command;
-        switch (getSimpleChannelUID(params.channelUID)) {
-            case CHANNEL_MOD_OP_ID: {
-                if (params.command instanceof DecimalType) {
-                    lgThinqACApiClientService.changeOperationMode(getBridgeId(), getDeviceId(),
-                            ((DecimalType) command).intValue());
-                } else {
-                    logger.warn("Received command different of Numeric in Mod Operation. Ignoring");
-                }
-                break;
-            }
-            case CHANNEL_FAN_SPEED_ID: {
-                if (command instanceof DecimalType) {
-                    lgThinqACApiClientService.changeFanSpeed(getBridgeId(), getDeviceId(),
-                            ((DecimalType) command).intValue());
-                } else {
-                    logger.warn("Received command different of Numeric in FanSpeed Channel. Ignoring");
-                }
-                break;
-            }
-            case CHANNEL_POWER_ID: {
-                if (command instanceof OnOffType) {
-                    lgThinqACApiClientService.turnDevicePower(getBridgeId(), getDeviceId(),
-                            command == OnOffType.ON ? DevicePowerState.DV_POWER_ON : DevicePowerState.DV_POWER_OFF);
-                } else {
-                    logger.warn("Received command different of OnOffType in Power Channel. Ignoring");
-                }
-                break;
-            }
-            case CHANNEL_COOL_JET_ID: {
-                if (command instanceof OnOffType) {
-                    lgThinqACApiClientService.turnCoolJetMode(getBridgeId(), getDeviceId(),
-                            command == OnOffType.ON ? getCapabilities().getCoolJetModeCommandOn()
-                                    : getCapabilities().getCoolJetModeCommandOff());
-                } else {
-                    logger.warn("Received command different of OnOffType in CoolJet Mode Channel. Ignoring");
-                }
-                break;
-            }
-            case CHANNEL_AIR_CLEAN_ID: {
-                if (command instanceof OnOffType) {
-                    lgThinqACApiClientService.turnAirCleanMode(getBridgeId(), getDeviceId(),
-                            command == OnOffType.ON ? getCapabilities().getAirCleanModeCommandOn()
-                                    : getCapabilities().getAirCleanModeCommandOff());
-                } else {
-                    logger.warn("Received command different of OnOffType in AirClean Mode Channel. Ignoring");
-                }
-                break;
-            }
-            case CHANNEL_AUTO_DRY_ID: {
-                if (command instanceof OnOffType) {
-                    lgThinqACApiClientService.turnAutoDryMode(getBridgeId(), getDeviceId(),
-                            command == OnOffType.ON ? getCapabilities().getAutoDryModeCommandOn()
-                                    : getCapabilities().getAutoDryModeCommandOff());
-                } else {
-                    logger.warn("Received command different of OnOffType in AutoDry Mode Channel. Ignoring");
-                }
-                break;
-            }
-            case CHANNEL_ENERGY_SAVING_ID: {
-                if (command instanceof OnOffType) {
-                    lgThinqACApiClientService.turnEnergySavingMode(getBridgeId(), getDeviceId(),
-                            command == OnOffType.ON ? getCapabilities().getEnergySavingModeCommandOn()
-                                    : getCapabilities().getEnergySavingModeCommandOff());
-                } else {
-                    logger.warn("Received command different of OnOffType in EvergySaving Mode Channel. Ignoring");
-                }
-                break;
-            }
-            case CHANNEL_TARGET_TEMP_ID: {
-                double targetTemp;
-                if (command instanceof DecimalType) {
-                    targetTemp = ((DecimalType) command).doubleValue();
-                } else if (command instanceof QuantityType) {
-                    targetTemp = ((QuantityType<?>) command).doubleValue();
-                } else {
-                    logger.warn("Received command different of Numeric in TargetTemp Channel. Ignoring");
-                    break;
-                }
-                lgThinqACApiClientService.changeTargetTemperature(getBridgeId(), getDeviceId(),
-                        ACTargetTmp.statusOf(targetTemp));
-                break;
-            }
-            case CHANNEL_EXTENDED_INFO_COLLECTOR_ID: {
-                break;
-            }
-            default: {
-                logger.error("Command {} to the channel {} not supported. Ignored.", command, params.channelUID);
-            }
-        }
-    }
-    // =========== Energy Colletor Implementation =============
+	protected void processCommand(AsyncCommandParams params) throws LGThinqApiException {
+		Command command = params.command;
+		switch (getSimpleChannelUID(params.channelUID)) {
+			case CHANNEL_MOD_OP_ID: {
+				if (params.command instanceof DecimalType) {
+					lgThinqACApiClientService.changeOperationMode(getBridgeId(), getDeviceId(),
+							((DecimalType) command).intValue());
+				} else {
+					logger.warn("Received command different of Numeric in Mod Operation. Ignoring");
+				}
+				break;
+			}
+			case CHANNEL_FAN_SPEED_ID: {
+				if (command instanceof DecimalType) {
+					lgThinqACApiClientService.changeFanSpeed(getBridgeId(), getDeviceId(),
+							((DecimalType) command).intValue());
+				} else {
+					logger.warn("Received command different of Numeric in FanSpeed Channel. Ignoring");
+				}
+				break;
+			}
+			case CHANNEL_POWER_ID: {
+				if (command instanceof OnOffType) {
+					lgThinqACApiClientService.turnDevicePower(getBridgeId(), getDeviceId(),
+							command == OnOffType.ON ? DevicePowerState.DV_POWER_ON : DevicePowerState.DV_POWER_OFF);
+				} else {
+					logger.warn("Received command different of OnOffType in Power Channel. Ignoring");
+				}
+				break;
+			}
+			case CHANNEL_COOL_JET_ID: {
+				if (command instanceof OnOffType) {
+					lgThinqACApiClientService.turnCoolJetMode(getBridgeId(), getDeviceId(),
+							command == OnOffType.ON ? getCapabilities().getCoolJetModeCommandOn()
+									: getCapabilities().getCoolJetModeCommandOff());
+				} else {
+					logger.warn("Received command different of OnOffType in CoolJet Mode Channel. Ignoring");
+				}
+				break;
+			}
+			case CHANNEL_AIR_CLEAN_ID: {
+				if (command instanceof OnOffType) {
+					lgThinqACApiClientService.turnAirCleanMode(getBridgeId(), getDeviceId(),
+							command == OnOffType.ON ? getCapabilities().getAirCleanModeCommandOn()
+									: getCapabilities().getAirCleanModeCommandOff());
+				} else {
+					logger.warn("Received command different of OnOffType in AirClean Mode Channel. Ignoring");
+				}
+				break;
+			}
+			case CHANNEL_AUTO_DRY_ID: {
+				if (command instanceof OnOffType) {
+					lgThinqACApiClientService.turnAutoDryMode(getBridgeId(), getDeviceId(),
+							command == OnOffType.ON ? getCapabilities().getAutoDryModeCommandOn()
+									: getCapabilities().getAutoDryModeCommandOff());
+				} else {
+					logger.warn("Received command different of OnOffType in AutoDry Mode Channel. Ignoring");
+				}
+				break;
+			}
+			case CHANNEL_ENERGY_SAVING_ID: {
+				if (command instanceof OnOffType) {
+					lgThinqACApiClientService.turnEnergySavingMode(getBridgeId(), getDeviceId(),
+							command == OnOffType.ON ? getCapabilities().getEnergySavingModeCommandOn()
+									: getCapabilities().getEnergySavingModeCommandOff());
+				} else {
+					logger.warn("Received command different of OnOffType in EvergySaving Mode Channel. Ignoring");
+				}
+				break;
+			}
+			case CHANNEL_TARGET_TEMP_ID: {
+				double targetTemp;
+				if (command instanceof DecimalType) {
+					targetTemp = ((DecimalType) command).doubleValue();
+				} else if (command instanceof QuantityType) {
+					targetTemp = ((QuantityType<?>) command).doubleValue();
+				} else {
+					logger.warn("Received command different of Numeric in TargetTemp Channel. Ignoring");
+					break;
+				}
+				lgThinqACApiClientService.changeTargetTemperature(getBridgeId(), getDeviceId(),
+						ACTargetTmp.statusOf(targetTemp));
+				break;
+			}
+			case CHANNEL_EXTENDED_INFO_COLLECTOR_ID: {
+				break;
+			}
+			default: {
+				logger.error("Command {} to the channel {} not supported. Ignored.", command, params.channelUID);
+			}
+		}
+	}
+	// =========== Energy Colletor Implementation =============
 
-    @Override
-    protected boolean isExtraInfoCollectorSupported() {
-        try {
-            return getCapabilities().isEnergyMonitorAvailable() || getCapabilities().isFilterMonitorAvailable();
-        } catch (LGThinqApiException e) {
-            logger.warn("Can't get capabilities of the device: {}", getDeviceId());
-        }
-        return false;
-    }
+	@Override
+	protected boolean isExtraInfoCollectorSupported() {
+		try {
+			return getCapabilities().isEnergyMonitorAvailable() || getCapabilities().isFilterMonitorAvailable();
+		} catch (LGThinqApiException e) {
+			logger.warn("Can't get capabilities of the device: {}", getDeviceId());
+		}
+		return false;
+	}
 
-    @Override
-    protected boolean isExtraInfoCollectorEnabled() {
-        return OnOffType.ON.toString().equals(getItemLinkedValue(extendedInfoCollectorChannelUID));
-    }
+	@Override
+	protected boolean isExtraInfoCollectorEnabled() {
+		return OnOffType.ON.toString().equals(getItemLinkedValue(extendedInfoCollectorChannelUID));
+	}
 
-    @Override
-    protected Map<String, Object> collectExtraInfoState() throws LGThinqException {
-        ExtendedDeviceInfo info = lgThinqACApiClientService.getExtendedDeviceInfo(getBridgeId(), getDeviceId());
-        return mapper.convertValue(info, new TypeReference<>() {
-        });
-    }
+	@Override
+	protected Map<String, Object> collectExtraInfoState() throws LGThinqException {
+		ExtendedDeviceInfo info = lgThinqACApiClientService.getExtendedDeviceInfo(getBridgeId(), getDeviceId());
+		return mapper.convertValue(info, new TypeReference<>() {
+		});
+	}
 
-    @Override
-    protected void updateExtraInfoStateChannels(Map<String, Object> energyStateAttributes) throws LGThinqException {
-        logger.debug("Calling updateExtraInfoStateChannels for device:{}", getDeviceAlias());
-        String instantPowerConsumption = (String) energyStateAttributes.get(EXTENDED_ATTR_INSTANT_POWER);
-        String filterUsed = (String) energyStateAttributes.get(EXTENDED_ATTR_FILTER_USED_TIME);
-        String filterTimelife = (String) energyStateAttributes.get(EXTENDED_ATTR_FILTER_MAX_TIME_TO_USE);
-        if (instantPowerConsumption == null) {
-            updateState(currentPowerEnergyChannelUID, UnDefType.NULL);
-        } else if (NumberUtils.isCreatable(instantPowerConsumption)) {
-            double ip = Double.parseDouble(instantPowerConsumption);
-            ip = ip / 1000;
-            updateState(currentPowerEnergyChannelUID, new QuantityType<>(ip, Units.KILOWATT_HOUR));
-        } else {
-            updateState(currentPowerEnergyChannelUID, UnDefType.UNDEF);
-        }
+	@Override
+	protected void updateExtraInfoStateChannels(Map<String, Object> energyStateAttributes) throws LGThinqException {
+		logger.debug("Calling updateExtraInfoStateChannels for device:{}", getDeviceAlias());
+		String instantPowerConsumption = (String) energyStateAttributes.get(EXTENDED_ATTR_INSTANT_POWER);
+		String filterUsed = (String) energyStateAttributes.get(EXTENDED_ATTR_FILTER_USED_TIME);
+		String filterTimelife = (String) energyStateAttributes.get(EXTENDED_ATTR_FILTER_MAX_TIME_TO_USE);
+		if (instantPowerConsumption == null) {
+			updateState(currentPowerEnergyChannelUID, UnDefType.NULL);
+		} else if (NumberUtils.isCreatable(instantPowerConsumption)) {
+			double ip = Double.parseDouble(instantPowerConsumption);
+			updateState(currentPowerEnergyChannelUID, new QuantityType<>(ip, Units.WATT));
+		} else {
+			updateState(currentPowerEnergyChannelUID, UnDefType.UNDEF);
+		}
 
-        if (filterTimelife == null || filterUsed == null) {
-            updateState(remainingFilterChannelUID, UnDefType.NULL);
-        } else if (NumberUtils.isCreatable(filterTimelife) && NumberUtils.isCreatable(filterUsed)) {
-            double used = Double.parseDouble(filterUsed);
-            double max = Double.parseDouble(filterTimelife);
+		if (filterTimelife == null || filterUsed == null) {
+			updateState(remainingFilterChannelUID, UnDefType.NULL);
+		} else if (NumberUtils.isCreatable(filterTimelife) && NumberUtils.isCreatable(filterUsed)) {
+			double used = Double.parseDouble(filterUsed);
+			double max = Double.parseDouble(filterTimelife);
             double perc = (1 - ((double) used / max)) * 100;
-            updateState(remainingFilterChannelUID, new QuantityType<>(perc, Units.PERCENT));
-        } else {
-            updateState(remainingFilterChannelUID, UnDefType.UNDEF);
-        }
-    }
+			updateState(remainingFilterChannelUID, new QuantityType<>(perc, Units.PERCENT));
+		} else {
+			updateState(remainingFilterChannelUID, UnDefType.UNDEF);
+		}
+	}
 }

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/handler/LGThinQFridgeHandler.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/handler/LGThinQFridgeHandler.java
@@ -26,13 +26,13 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.lgthinq.internal.LGThinQStateDescriptionProvider;
 import org.openhab.binding.lgthinq.internal.errors.LGThinqApiException;
 import org.openhab.binding.lgthinq.lgservices.LGThinQApiClientService;
+import org.openhab.binding.lgthinq.lgservices.LGThinQApiClientServiceFactory;
 import org.openhab.binding.lgthinq.lgservices.LGThinQFridgeApiClientService;
-import org.openhab.binding.lgthinq.lgservices.LGThinQFridgeApiV1ClientServiceImpl;
-import org.openhab.binding.lgthinq.lgservices.LGThinQFridgeApiV2ClientServiceImpl;
 import org.openhab.binding.lgthinq.lgservices.model.DeviceTypes;
 import org.openhab.binding.lgthinq.lgservices.model.LGDevice;
 import org.openhab.binding.lgthinq.lgservices.model.devices.fridge.FridgeCanonicalSnapshot;
 import org.openhab.binding.lgthinq.lgservices.model.devices.fridge.FridgeCapability;
+import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
@@ -69,11 +69,9 @@ public class LGThinQFridgeHandler extends LGThinQAbstractDeviceHandler<FridgeCap
     private @Nullable ScheduledFuture<?> thingStatePollingJob;
 
     public LGThinQFridgeHandler(Thing thing, LGThinQStateDescriptionProvider stateDescriptionProvider,
-            ItemChannelLinkRegistry itemChannelLinkRegistry) {
+            ItemChannelLinkRegistry itemChannelLinkRegistry, HttpClientFactory httpClientFactory) {
         super(thing, stateDescriptionProvider, itemChannelLinkRegistry);
-        lgThinqFridgeApiClientService = lgPlatformType.equals(PLATFORM_TYPE_V1)
-                ? LGThinQFridgeApiV1ClientServiceImpl.getInstance()
-                : LGThinQFridgeApiV2ClientServiceImpl.getInstance();
+        lgThinqFridgeApiClientService = LGThinQApiClientServiceFactory.newFridgeApiClientService(lgPlatformType, httpClientFactory);
         channelGroupDashboardUID = new ChannelGroupUID(getThing().getUID(), CHANNEL_DASHBOARD_GRP_ID);
         channelGroupExtendedInfoUID = new ChannelGroupUID(getThing().getUID(), CHANNEL_EXTENDED_INFO_GRP_ID);
         fridgeTempChannelUID = new ChannelUID(channelGroupDashboardUID, CHANNEL_FRIDGE_TEMP_ID);

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/handler/LGThinQWasherDryerHandler.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/internal/handler/LGThinQWasherDryerHandler.java
@@ -32,6 +32,7 @@ import org.openhab.binding.lgthinq.lgservices.model.DevicePowerState;
 import org.openhab.binding.lgthinq.lgservices.model.DeviceTypes;
 import org.openhab.binding.lgthinq.lgservices.model.LGDevice;
 import org.openhab.binding.lgthinq.lgservices.model.devices.washerdryer.*;
+import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.*;
@@ -83,14 +84,12 @@ public class LGThinQWasherDryerHandler
 
     public LGThinQWasherDryerHandler(Thing thing, LGThinQStateDescriptionProvider stateDescriptionProvider,
             ThinqChannelTypeProvider channelTypeProvider, ThinqChannelGroupTypeProvider channelGroupTypeProvider,
-            ItemChannelLinkRegistry itemChannelLinkRegistry) {
+            ItemChannelLinkRegistry itemChannelLinkRegistry, HttpClientFactory httpClientFactory) {
         super(thing, stateDescriptionProvider, itemChannelLinkRegistry);
         this.thinqChannelGroupProvider = channelGroupTypeProvider;
         this.thinqChannelProvider = channelTypeProvider;
         this.stateDescriptionProvider = stateDescriptionProvider;
-        lgThinqWMApiClientService = lgPlatformType.equals(PLATFORM_TYPE_V1)
-                ? LGThinQWMApiV1ClientServiceImpl.getInstance()
-                : LGThinQWMApiV2ClientServiceImpl.getInstance();
+        lgThinqWMApiClientService = LGThinQApiClientServiceFactory.newWMApiClientService(lgPlatformType, httpClientFactory);
         channelGroupRemoteStartUID = new ChannelGroupUID(getThing().getUID(), WM_CHANNEL_REMOTE_START_GRP_ID);
         channelGroupDashboardUID = new ChannelGroupUID(getThing().getUID(), CHANNEL_DASHBOARD_GRP_ID);
         courseChannelUID = new ChannelUID(channelGroupDashboardUID, WM_CHANNEL_COURSE_ID);

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQACApiV1ClientServiceImpl.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQACApiV1ClientServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.Base64;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.lgthinq.internal.api.RestResult;
 import org.openhab.binding.lgthinq.internal.errors.LGThinqApiException;
 import org.openhab.binding.lgthinq.lgservices.model.CapabilityDefinition;
@@ -42,25 +43,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 @NonNullByDefault
 public class LGThinQACApiV1ClientServiceImpl extends
         LGThinQAbstractApiV1ClientService<ACCapability, ACCanonicalSnapshot> implements LGThinQACApiClientService {
-    private static final LGThinQACApiClientService instance;
-    private static final Logger logger = LoggerFactory.getLogger(LGThinQACApiV1ClientServiceImpl.class);
 
-    static {
-        instance = new LGThinQACApiV1ClientServiceImpl(ACCapability.class, ACCanonicalSnapshot.class);
-    }
+	private static final Logger logger = LoggerFactory.getLogger(LGThinQACApiV1ClientServiceImpl.class);
 
-    protected LGThinQACApiV1ClientServiceImpl(Class<ACCapability> capabilityClass,
-            Class<ACCanonicalSnapshot> snapshotClass) {
-        super(capabilityClass, snapshotClass);
+    protected LGThinQACApiV1ClientServiceImpl(HttpClient httpClient) {
+        super(ACCapability.class, ACCanonicalSnapshot.class, httpClient);
     }
 
     @Override
     protected void beforeGetDataDevice(@NonNull String bridgeName, @NonNull String deviceId) {
         // Nothing to do on V1 ACCapability here
-    }
-
-    public static LGThinQACApiClientService getInstance() {
-        return instance;
     }
 
     /**

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQACApiV2ClientServiceImpl.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQACApiV2ClientServiceImpl.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.lgthinq.internal.api.RestResult;
 import org.openhab.binding.lgthinq.internal.errors.LGThinqApiException;
 import org.openhab.binding.lgthinq.internal.errors.LGThinqDeviceV1MonitorExpiredException;
@@ -43,23 +44,14 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @NonNullByDefault
 public class LGThinQACApiV2ClientServiceImpl extends
         LGThinQAbstractApiV2ClientService<ACCapability, ACCanonicalSnapshot> implements LGThinQACApiClientService {
-    private static final LGThinQACApiClientService instance;
-    private static final Logger logger = LoggerFactory.getLogger(LGThinQACApiV2ClientServiceImpl.class);
 
-    static {
-        instance = new LGThinQACApiV2ClientServiceImpl(ACCapability.class, ACCanonicalSnapshot.class);
+	private static final Logger logger = LoggerFactory.getLogger(LGThinQACApiV2ClientServiceImpl.class);
+
+    protected LGThinQACApiV2ClientServiceImpl(HttpClient httpClient) {
+        super(ACCapability.class, ACCanonicalSnapshot.class, httpClient);
     }
 
-    protected LGThinQACApiV2ClientServiceImpl(Class<ACCapability> capabilityClass,
-            Class<ACCanonicalSnapshot> snapshotClass) {
-        super(capabilityClass, snapshotClass);
-    }
-
-    public static LGThinQACApiClientService getInstance() {
-        return instance;
-    }
-
-    @Override
+	@Override
     public void turnDevicePower(String bridgeName, String deviceId, DevicePowerState newPowerState)
             throws LGThinqApiException {
         try {
@@ -233,7 +225,7 @@ public class LGThinQACApiV2ClientServiceImpl extends
         } catch (LGThinqApiException e) {
             throw e;
         } catch (Exception e) {
-            throw new LGThinqApiException("Error sending command to LG API", e);
+            throw new LGThinqApiException("Error sending command to LG API: " + e.getMessage(), e);
         }
     }
 }

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQAbstractApiV1ClientService.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQAbstractApiV1ClientService.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.lgthinq.internal.api.RestResult;
 import org.openhab.binding.lgthinq.internal.api.RestUtils;
 import org.openhab.binding.lgthinq.internal.api.TokenResult;
@@ -48,8 +49,8 @@ public abstract class LGThinQAbstractApiV1ClientService<C extends CapabilityDefi
         extends LGThinQAbstractApiClientService<C, S> {
     private static final Logger logger = LoggerFactory.getLogger(LGThinQAbstractApiV1ClientService.class);
 
-    protected LGThinQAbstractApiV1ClientService(Class<C> capabilityClass, Class<S> snapshotClass) {
-        super(capabilityClass, snapshotClass);
+    protected LGThinQAbstractApiV1ClientService(Class<C> capabilityClass, Class<S> snapshotClass, HttpClient httpClient) {
+        super(capabilityClass, snapshotClass, httpClient);
     }
 
     @Override
@@ -99,7 +100,7 @@ public abstract class LGThinQAbstractApiV1ClientService<C extends CapabilityDefi
         rootNode.set("lgedmRoot", bodyNode);
         String url = builder.build().toURL().toString();
         logger.debug("URL: {}, Post Payload:[{}]", url, rootNode.toPrettyString());
-        RestResult resp = RestUtils.postCall(url, headers, rootNode.toPrettyString());
+        RestResult resp = RestUtils.postCall(httpClient, url, headers, rootNode.toPrettyString());
         if (resp == null) {
             logger.warn("Null result returned sending command to LG API V1");
             throw new LGThinqApiException("Null result returned sending command to LG API V1");

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQAbstractApiV2ClientService.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQAbstractApiV2ClientService.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.lgthinq.internal.api.RestResult;
 import org.openhab.binding.lgthinq.internal.api.RestUtils;
 import org.openhab.binding.lgthinq.internal.api.TokenResult;
@@ -47,8 +48,8 @@ public abstract class LGThinQAbstractApiV2ClientService<C extends CapabilityDefi
         extends LGThinQAbstractApiClientService<C, S> {
     private static final Logger logger = LoggerFactory.getLogger(LGThinQAbstractApiV2ClientService.class);
 
-    protected LGThinQAbstractApiV2ClientService(Class<C> capabilityClass, Class<S> snapshotClass) {
-        super(capabilityClass, snapshotClass);
+    protected LGThinQAbstractApiV2ClientService(Class<C> capabilityClass, Class<S> snapshotClass, HttpClient httpClient) {
+        super(capabilityClass, snapshotClass, httpClient);
     }
 
     @Override	
@@ -64,7 +65,7 @@ public abstract class LGThinQAbstractApiV2ClientService<C extends CapabilityDefi
                 .path(String.format(V2_CTRL_DEVICE_CONFIG_PATH, deviceId, controlPath));
         Map<String, String> headers = getCommonV2Headers(token.getGatewayInfo().getLanguage(),
                 token.getGatewayInfo().getCountry(), token.getAccessToken(), token.getUserInfo().getUserNumber());
-        RestResult resp = RestUtils.postCall(builder.build().toURL().toString(), headers, payload);
+        RestResult resp = RestUtils.postCall(httpClient, builder.build().toURL().toString(), headers, payload);
         if (resp == null) {
             logger.warn("Null result returned sending command to LG API V2: {}, {}, {}", deviceId, controlPath, payload);
             throw new LGThinqApiException("Null result returned sending command to LG API V2");

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQApiClientServiceFactory.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQApiClientServiceFactory.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.lgthinq.lgservices;
+
+import static org.openhab.binding.lgthinq.internal.LGThinQBindingConstants.PLATFORM_TYPE_V1;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
+import org.openhab.binding.lgthinq.internal.api.RestResult;
+import org.openhab.binding.lgthinq.internal.errors.LGThinqApiException;
+import org.openhab.binding.lgthinq.lgservices.model.AbstractCapability;
+import org.openhab.binding.lgthinq.lgservices.model.AbstractSnapshotDefinition;
+import org.openhab.binding.lgthinq.lgservices.model.DevicePowerState;
+import org.openhab.core.io.net.http.HttpClientFactory;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Creates expecialized API clients.
+ * 
+ * @author Julio Gesser
+ */
+public class LGThinQApiClientServiceFactory {
+
+    public static LGThinQGeneralApiClientService newGeneralApiClientService(HttpClientFactory httpClientFactory) {
+        return new LGThinQGeneralApiClientService(httpClientFactory.getCommonHttpClient());
+    }
+
+    public static LGThinQACApiClientService newACApiClientService(String lgPlatformType, HttpClientFactory httpClientFactory) {
+        return lgPlatformType.equals(PLATFORM_TYPE_V1)
+                ? new LGThinQACApiV1ClientServiceImpl(httpClientFactory.getCommonHttpClient())
+                : new LGThinQACApiV2ClientServiceImpl(httpClientFactory.getCommonHttpClient());
+    }
+
+    public static LGThinQFridgeApiClientService newFridgeApiClientService(String lgPlatformType, HttpClientFactory httpClientFactory) {
+        return lgPlatformType.equals(PLATFORM_TYPE_V1)
+                ? new LGThinQFridgeApiV1ClientServiceImpl(httpClientFactory.getCommonHttpClient())
+                : new LGThinQFridgeApiV2ClientServiceImpl(httpClientFactory.getCommonHttpClient());
+    }
+
+    public static LGThinQWMApiClientService newWMApiClientService(String lgPlatformType, HttpClientFactory httpClientFactory) {
+        return lgPlatformType.equals(PLATFORM_TYPE_V1)
+                ? new LGThinQWMApiV1ClientServiceImpl(httpClientFactory.getCommonHttpClient())
+                : new LGThinQWMApiV2ClientServiceImpl(httpClientFactory.getCommonHttpClient());
+    }
+
+    @NonNullByDefault
+    public static final class LGThinQGeneralApiClientService extends LGThinQAbstractApiClientService<GenericCapability, AbstractSnapshotDefinition> {
+
+        private LGThinQGeneralApiClientService(HttpClient httpClient) {
+            super(GenericCapability.class, AbstractSnapshotDefinition.class, httpClient);
+        }
+
+        @Override
+        public void turnDevicePower(String bridgeName, String deviceId, DevicePowerState newPowerState) throws LGThinqApiException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected void beforeGetDataDevice(@NonNull String bridgeName, @NonNull String deviceId) throws LGThinqApiException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected RestResult sendCommand(String bridgeName, String deviceId, String controlPath, String controlKey, String command, String keyName, String value) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected RestResult sendCommand(String bridgeName, String deviceId, String controlPath, String controlKey, String command, @Nullable String keyName, @Nullable String value, @Nullable ObjectNode extraNode) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected Map<String, Object> handleGenericErrorResult(@Nullable RestResult resp) throws LGThinqApiException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @NonNullByDefault
+    private static final class GenericCapability extends AbstractCapability<GenericCapability> {
+
+    }
+}

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQDRApiV2ClientServiceImpl.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQDRApiV2ClientServiceImpl.java
@@ -14,6 +14,7 @@ package org.openhab.binding.lgthinq.lgservices;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.lgthinq.internal.api.RestResult;
 import org.openhab.binding.lgthinq.internal.errors.LGThinqApiException;
 import org.openhab.binding.lgthinq.lgservices.model.DevicePowerState;
@@ -30,23 +31,13 @@ public class LGThinQDRApiV2ClientServiceImpl
         extends LGThinQAbstractApiV2ClientService<WasherDryerCapability, WasherDryerSnapshot>
         implements LGThinQDRApiClientService {
 
-    private static final LGThinQDRApiV2ClientServiceImpl instance;
-    static {
-        instance = new LGThinQDRApiV2ClientServiceImpl(WasherDryerCapability.class, WasherDryerSnapshot.class);
-    }
-
-    protected LGThinQDRApiV2ClientServiceImpl(Class<WasherDryerCapability> capabilityClass,
-            Class<WasherDryerSnapshot> snapshotClass) {
-        super(capabilityClass, snapshotClass);
+    protected LGThinQDRApiV2ClientServiceImpl(HttpClient httpClient) {
+        super(WasherDryerCapability.class, WasherDryerSnapshot.class, httpClient);
     }
 
     @Override
     protected void beforeGetDataDevice(@NonNull String bridgeName, @NonNull String deviceId) {
         // TODO - Analise what to do here
-    }
-
-    public static LGThinQDRApiV2ClientServiceImpl getInstance() {
-        return instance;
     }
 
     @Override

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQFridgeApiV1ClientServiceImpl.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQFridgeApiV1ClientServiceImpl.java
@@ -15,6 +15,7 @@ package org.openhab.binding.lgthinq.lgservices;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.lgthinq.internal.errors.LGThinqApiException;
 import org.openhab.binding.lgthinq.lgservices.model.CapabilityDefinition;
 import org.openhab.binding.lgthinq.lgservices.model.DevicePowerState;
@@ -31,23 +32,13 @@ public class LGThinQFridgeApiV1ClientServiceImpl
         extends LGThinQAbstractApiV1ClientService<FridgeCapability, FridgeCanonicalSnapshot>
         implements LGThinQFridgeApiClientService {
 
-    private static final LGThinQFridgeApiClientService instance;
-    static {
-        instance = new LGThinQFridgeApiV1ClientServiceImpl(FridgeCapability.class, FridgeCanonicalSnapshot.class);
-    }
-
-    protected LGThinQFridgeApiV1ClientServiceImpl(Class<FridgeCapability> capabilityClass,
-            Class<FridgeCanonicalSnapshot> snapshotClass) {
-        super(capabilityClass, snapshotClass);
+    protected LGThinQFridgeApiV1ClientServiceImpl(HttpClient httpClient) {
+        super(FridgeCapability.class, FridgeCanonicalSnapshot.class, httpClient);
     }
 
     @Override
     protected void beforeGetDataDevice(@NonNull String bridgeName, @NonNull String deviceId) {
         // Nothing to do for V1 thinq
-    }
-
-    public static LGThinQFridgeApiClientService getInstance() {
-        return instance;
     }
 
     @Override

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQFridgeApiV2ClientServiceImpl.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQFridgeApiV2ClientServiceImpl.java
@@ -14,6 +14,7 @@ package org.openhab.binding.lgthinq.lgservices;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.lgthinq.internal.errors.LGThinqApiException;
 import org.openhab.binding.lgthinq.lgservices.model.DevicePowerState;
 import org.openhab.binding.lgthinq.lgservices.model.devices.fridge.FridgeCanonicalSnapshot;
@@ -29,23 +30,13 @@ public class LGThinQFridgeApiV2ClientServiceImpl
         extends LGThinQAbstractApiV2ClientService<FridgeCapability, FridgeCanonicalSnapshot>
         implements LGThinQFridgeApiClientService {
 
-    private static final LGThinQFridgeApiClientService instance;
-    static {
-        instance = new LGThinQFridgeApiV2ClientServiceImpl(FridgeCapability.class, FridgeCanonicalSnapshot.class);
-    }
-
-    protected LGThinQFridgeApiV2ClientServiceImpl(Class<FridgeCapability> capabilityClass,
-            Class<FridgeCanonicalSnapshot> snapshotClass) {
-        super(capabilityClass, snapshotClass);
+    protected LGThinQFridgeApiV2ClientServiceImpl(HttpClient httpClient) {
+        super(FridgeCapability.class, FridgeCanonicalSnapshot.class, httpClient);
     }
 
     @Override
     protected void beforeGetDataDevice(@NonNull String bridgeName, @NonNull String deviceId) {
         // TODO - Analise what to do here
-    }
-
-    public static LGThinQFridgeApiClientService getInstance() {
-        return instance;
     }
 
     @Override

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQWMApiV1ClientServiceImpl.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQWMApiV1ClientServiceImpl.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.lgthinq.internal.api.RestResult;
 import org.openhab.binding.lgthinq.internal.errors.LGThinqApiException;
 import org.openhab.binding.lgthinq.lgservices.model.CapabilityDefinition;
@@ -41,23 +42,14 @@ public class LGThinQWMApiV1ClientServiceImpl
         extends LGThinQAbstractApiV1ClientService<WasherDryerCapability, WasherDryerSnapshot>
         implements LGThinQWMApiClientService {
     private final Logger logger = LoggerFactory.getLogger(LGThinQWMApiV1ClientServiceImpl.class);
-    private static final LGThinQWMApiClientService instance;
-    static {
-        instance = new LGThinQWMApiV1ClientServiceImpl(WasherDryerCapability.class, WasherDryerSnapshot.class);
-    }
 
-    protected LGThinQWMApiV1ClientServiceImpl(Class<WasherDryerCapability> capabilityClass,
-            Class<WasherDryerSnapshot> snapshotClass) {
-        super(capabilityClass, snapshotClass);
+    protected LGThinQWMApiV1ClientServiceImpl(HttpClient httpClient) {
+        super(WasherDryerCapability.class, WasherDryerSnapshot.class, httpClient);
     }
 
     @Override
     protected void beforeGetDataDevice(@NonNull String bridgeName, @NonNull String deviceId) {
         // Nothing to do for V1 thinq
-    }
-
-    public static LGThinQWMApiClientService getInstance() {
-        return instance;
     }
 
     @Override

--- a/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQWMApiV2ClientServiceImpl.java
+++ b/bundles/org.openhab.binding.lgthinq/src/main/java/org/openhab/binding/lgthinq/lgservices/LGThinQWMApiV2ClientServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
 import org.openhab.binding.lgthinq.internal.api.RestResult;
 import org.openhab.binding.lgthinq.internal.errors.LGThinqApiException;
 import org.openhab.binding.lgthinq.lgservices.model.CommandDefinition;
@@ -38,23 +39,13 @@ public class LGThinQWMApiV2ClientServiceImpl
         extends LGThinQAbstractApiV2ClientService<WasherDryerCapability, WasherDryerSnapshot>
         implements LGThinQWMApiClientService {
 
-    private static final LGThinQWMApiClientService instance;
-    static {
-        instance = new LGThinQWMApiV2ClientServiceImpl(WasherDryerCapability.class, WasherDryerSnapshot.class);
-    }
-
-    protected LGThinQWMApiV2ClientServiceImpl(Class<WasherDryerCapability> capabilityClass,
-            Class<WasherDryerSnapshot> snapshotClass) {
-        super(capabilityClass, snapshotClass);
+    protected LGThinQWMApiV2ClientServiceImpl(HttpClient httpClient) {
+        super(WasherDryerCapability.class, WasherDryerSnapshot.class, httpClient);
     }
 
     @Override
     protected void beforeGetDataDevice(@NonNull String bridgeName, @NonNull String deviceId) {
         // TODO - Analise what to do here
-    }
-
-    public static LGThinQWMApiClientService getInstance() {
-        return instance;
     }
 
     @Override

--- a/bundles/org.openhab.binding.lgthinq/src/test/java/org/openhab/binding/lgthinq/handler/LGThinqBridgeTests.java
+++ b/bundles/org.openhab.binding.lgthinq/src/test/java/org/openhab/binding/lgthinq/handler/LGThinqBridgeTests.java
@@ -27,6 +27,7 @@ import java.util.*;
 
 import javax.ws.rs.core.UriBuilder;
 
+import org.eclipse.jetty.client.HttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +39,7 @@ import org.openhab.binding.lgthinq.internal.api.TokenManager;
 import org.openhab.binding.lgthinq.internal.handler.LGThinQBridgeHandler;
 import org.openhab.binding.lgthinq.lgservices.*;
 import org.openhab.binding.lgthinq.lgservices.model.LGDevice;
+import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ThingUID;
 import org.slf4j.Logger;
@@ -85,8 +87,8 @@ class LGThinqBridgeTests {
     @Test
     public void testDiscoveryACThings() {
         setupAuthenticationMock();
-        LGThinQApiClientService service1 = LGThinQACApiV1ClientServiceImpl.getInstance();
-        LGThinQApiClientService service2 = LGThinQACApiV2ClientServiceImpl.getInstance();
+        LGThinQApiClientService service1 = LGThinQApiClientServiceFactory.newACApiClientService(PLATFORM_TYPE_V1, mock(HttpClientFactory.class));
+        LGThinQApiClientService service2 = LGThinQApiClientServiceFactory.newACApiClientService(PLATFORM_TYPE_V2, mock(HttpClientFactory.class));
         try {
             List<LGDevice> devices = service2.listAccountDevices("bridgeTest");
             assertEquals(devices.size(), 2);
@@ -128,12 +130,12 @@ class LGThinqBridgeTests {
         String tempDir = System.getProperty("java.io.tmpdir");
         LGThinQBindingConstants.THINQ_CONNECTION_DATA_FILE = tempDir + File.separator + "token.json";
         LGThinQBindingConstants.BASE_CAP_CONFIG_DATA_FILE = tempDir + File.separator + "thinq-cap.json";
-        LGThinQBridgeHandler b = new LGThinQBridgeHandler(fakeThing);
+        LGThinQBridgeHandler b = new LGThinQBridgeHandler(fakeThing, mock(HttpClientFactory.class));
         LGThinQBridgeHandler spyBridge = spy(b);
         doReturn(new LGThinQBridgeConfiguration(fakeUserName, fakePassword, fakeCountry, fakeLanguage, 60,
                 "http://localhost:8880")).when(spyBridge).getConfigAs(any(Class.class));
         spyBridge.initialize();
-        TokenManager tokenManager = TokenManager.getInstance();
+        TokenManager tokenManager = new TokenManager(mock(HttpClient.class));
         try {
             if (!tokenManager.isOauthTokenRegistered(fakeBridgeName)) {
                 tokenManager.oauthFirstRegistration(fakeBridgeName, fakeLanguage, fakeCountry, fakeUserNameEncoded,
@@ -187,10 +189,10 @@ class LGThinqBridgeTests {
         LGThinQBindingConstants.THINQ_USER_DATA_FOLDER = "" + tempDir;
         LGThinQBindingConstants.THINQ_CONNECTION_DATA_FILE = tempDir + File.separator + "token.json";
         LGThinQBindingConstants.BASE_CAP_CONFIG_DATA_FILE = tempDir + File.separator + "thinq-cap.json";
-        LGThinQBridgeHandler b = new LGThinQBridgeHandler(fakeThing);
+        LGThinQBridgeHandler b = new LGThinQBridgeHandler(fakeThing, mock(HttpClientFactory.class));
 
-        final LGThinQWMApiClientService service2 = LGThinQWMApiV2ClientServiceImpl.getInstance();
-        TokenManager tokenManager = TokenManager.getInstance();
+        final LGThinQWMApiClientService service2 = LGThinQApiClientServiceFactory.newWMApiClientService(PLATFORM_TYPE_V1, mock(HttpClientFactory.class));
+        TokenManager tokenManager = new TokenManager(mock(HttpClient.class));
         try {
             if (!tokenManager.isOauthTokenRegistered(fakeBridgeName)) {
                 tokenManager.oauthFirstRegistration(fakeBridgeName, fakeLanguage, fakeCountry, fakeUserName,


### PR DESCRIPTION
Hi @nemerdaud, here is a new PR with some contributions.
I made some changes to replace the Apache HttpClient with the Jetty HttpClient provided by the OpenHab runtime.
This change reduces the footprint of this binding and fixes some memory leaks caused by static references to the apache client.

I only have Air Conditioner devices to test and it is working fine here for more than 3 weeks.
